### PR TITLE
Issues with augs::trivial_tuple

### DIFF
--- a/augs/misc/trivial_tuple.h
+++ b/augs/misc/trivial_tuple.h
@@ -7,7 +7,7 @@ namespace augs {
 	class trivial_tuple {
 		typedef std::tuple<Types...> tuple_type;
 
-		char buf[sizeof(std::tuple<Types...>)];
+		alignas(tuple_type) char buf[sizeof(tuple_type)];
 	public:
 		static_assert(are_types_memcpy_safe_v<Types...>, "one of the types is not trivial!");
 


### PR DESCRIPTION
Well, this fix does nothing on current compiler/platform, but still augs::trivial_tuple and is_memcpy_safe have some issues: std::tuple hardcoded trivially constructible/copiable (I think, you just dodged this issue for better times).

Another issue with it's user, augs::component_aggregate: it has field component_ids with type trivial_tuple<pool_id<components>...>, and actually pool_id isn't trivially constructible: it has constructor which assigns index=-1 and version=0. But trivial_tuple does not call default constructors on its elements, and whole class augs::component_aggregate assumed to be trivially constructible. Since object of this class stored inside pool, they are constructed by using std::allocator which construct it's type like expression "T()", yielding zero-initialization. So actual starting values became index=0 and version=0 in this case. By coincidence (or not?) it's considered as invalid pool_id since version is always > 0. So augs::component_allocators_mixin::find<component> works as intended when trying to find not presented component. That was confusing.