### PR TITLE
Building on Windows with VS 2022

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1906,6 +1906,10 @@ if(MSVC_SPECIFIC)
 	set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT Hypersomnia)
 endif()
 
+if(MSVC AND GENERATE_DEBUG_INFORMATION)
+	set_target_properties(Hypersomnia PROPERTIES COMPILE_PDB_NAME Hypersomnia COMPILE_PDB_OUTPUT_DIR ${CMAKE_BINARY_DIR})
+endif()
+
 # We add a command to automatically create an archive for every Release build.
 
 # Custom targets for Makefile

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -1,0 +1,14 @@
+﻿{
+  "configurations": [
+    {
+      "name": "x64-Debug",
+      "generator": "Ninja",
+      "configurationType": "Debug",
+      "inheritEnvironments": [ "clang_cl_x64_x64" ],
+      "buildRoot": "${projectDir}\\out\\build\\${name}",
+      "installRoot": "${projectDir}\\out\\install\\${name}",
+      "cmakeCommandArgs": "cmake -G Ninja -DLINK_STEAM_INTEGRATION=1 -DCMAKE_LINKER=lld-link -DARCHITECTURE=\"x64\" -DGENERATE_DEBUG_INFORMATION=1 -DBUILD_DEBUGGER_SETUP=0 -DOUTPUT_TO_HYPERSOMNIA_FOLDER=1 -DOPENSSL_ROOT_DIR=C:\\OpenSSL-Win64",
+      "ctestCommandArgs": ""
+    }
+  ]
+}

--- a/src/augs/misc/time_utils.cpp
+++ b/src/augs/misc/time_utils.cpp
@@ -2,6 +2,7 @@
 #include <iomanip>
 #include <sstream>
 #include <filesystem>
+#include <mutex>
 
 #include "augs/string/typesafe_sprintf.h"
 #include "augs/misc/time_utils.h"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,6 +10,7 @@
 
 #include "cmd_line_params.h"
 #include "build_info.h"
+#include <mutex>
 
 extern std::mutex log_mutex;
 


### PR DESCRIPTION
Fixes "no type named 'mutex' in namespace 'std'" error
Creates a PDB file when GENERATE_DEBUG_INFORMATION is enabled
CMakeSettings.json for building from Visual Studio