### PR TITLE
Fix potential vulnerable cloned function

### DIFF
--- a/src/3rdparty/freetype2/src/gzip/inflate.c
+++ b/src/3rdparty/freetype2/src/gzip/inflate.c
@@ -770,8 +770,9 @@ int ZEXPORT inflate(
                 if (copy > have) copy = have;
                 if (copy) {
                     if (state->head != Z_NULL &&
-                        state->head->extra != Z_NULL) {
-                        len = state->head->extra_len - state->length;
+                        state->head->extra != Z_NULL &&
+                        (len = state->head->extra_len - state->length) <
+                            state->head->extra_max) {
                         zmemcpy(state->head->extra + len, next,
                                 len + copy > state->head->extra_max ?
                                 state->head->extra_max - len : copy);


### PR DESCRIPTION
Hi Development Team,

I identified a potential vulnerability in a clone function inflate() in `src/3rdparty/freetype2/src/gzip/inflate.c` sourced from [madler/zlib](https://github.com/madler/zlib). This issue, originally reported in [CVE-2022-37434](https://nvd.nist.gov/vuln/detail/https://github.com/advisories/CVE-2022-37434), was resolved in the repository via this commit https://github.com/madler/zlib/commit/eff308af425b67093bab25f80f1ae950166bece1.

The patch from https://github.com/madler/zlib/commit/eff308af425b67093bab25f80f1ae950166bece1 fix the vulnerability, but it induces a new bug. This PR applies the corresponding patch from https://github.com/madler/zlib/commit/1eb7682f845ac9e9bf9ae35bbfb3bad5dacbd91d to solve the problem.

Please review at your convenience. Thank you!