### PR TITLE
Fix GCC build on Fedora

### DIFF
--- a/src/application/arena/arena_handle.hpp
+++ b/src/application/arena/arena_handle.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 
 template <bool C, class ModeVariant, class RulesVariant>
 class basic_arena_handle;

--- a/src/application/arena/build_arena_from_editor_project.hpp
+++ b/src/application/arena/build_arena_from_editor_project.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "game/cosmos/per_entity_type.h"
 #include "application/setups/editor/project/editor_project.hpp"
 #include "application/setups/editor/editor_rebuild_prefab_nodes.hpp"

--- a/src/application/arena/synced_dynamic_vars.h
+++ b/src/application/arena/synced_dynamic_vars.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include "application/setups/server/server_vars.h"
 #include "game/modes/mode_player_id.h"
 

--- a/src/application/config_json_table.h
+++ b/src/application/config_json_table.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include <string>
 #include "3rdparty/imgui/imgui.h"
 

--- a/src/application/gui/browse_servers_gui.cpp
+++ b/src/application/gui/browse_servers_gui.cpp
@@ -1,3 +1,5 @@
+#include <cstddef>
+#include <cstdint>
 #include "augs/misc/future.h"
 
 #include "application/gui/browse_servers_gui.h"

--- a/src/application/gui/browse_servers_gui.h
+++ b/src/application/gui/browse_servers_gui.h
@@ -1,4 +1,6 @@
 #pragma once
+#include <cstddef>
+#include <cstdint>
 #include "augs/math/vec2.h"
 #include "augs/misc/imgui/standard_window_mixin.h"
 #include "augs/misc/timing/timer.h"

--- a/src/application/gui/client/chat_gui.cpp
+++ b/src/application/gui/client/chat_gui.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "application/gui/client/chat_gui.h"
 #include "augs/misc/imgui/imgui_scope_wrappers.h"
 #include "augs/misc/imgui/imgui_control_wrappers.h"

--- a/src/application/gui/headless_map_catalogue.cpp
+++ b/src/application/gui/headless_map_catalogue.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include <future>
 #include <mutex>
 #include "application/gui/headless_map_catalogue.h"

--- a/src/application/gui/headless_map_catalogue.h
+++ b/src/application/gui/headless_map_catalogue.h
@@ -1,4 +1,6 @@
 #pragma once
+#include <cstddef>
+#include <cstdint>
 #include "augs/misc/future.h"
 #include <unordered_set>
 #include "augs/network/network_types.h"

--- a/src/application/gui/headless_map_catalogue.hpp
+++ b/src/application/gui/headless_map_catalogue.hpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 template <class F>
 void multi_arena_synchronizer::for_each_with_progress(F callback) const {
 	/* 

--- a/src/application/gui/ingame_menu_gui.h
+++ b/src/application/gui/ingame_menu_gui.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "augs/misc/machine_entropy.h"
 #include "augs/gui/formatted_string.h"
 #include "augs/templates/enum_introspect.h"

--- a/src/application/gui/leaderboards_gui.cpp
+++ b/src/application/gui/leaderboards_gui.cpp
@@ -1,3 +1,5 @@
+#include <cstddef>
+#include <cstdint>
 #include "application/gui/leaderboards_gui.h"
 
 #include "application/gui/leaderboards_gui.h"

--- a/src/application/gui/main_menu_gui.h
+++ b/src/application/gui/main_menu_gui.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "augs/misc/machine_entropy.h"
 #include "augs/gui/formatted_string.h"
 #include "augs/string/format_enum.h"

--- a/src/application/gui/map_catalogue_gui.cpp
+++ b/src/application/gui/map_catalogue_gui.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include <future>
 #include <mutex>
 #include "application/setups/client/arena_downloading_session.h"

--- a/src/application/gui/menu/locations/menu_root_in_context.h
+++ b/src/application/gui/menu/locations/menu_root_in_context.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 
 template <class Enum>
 class menu_root;

--- a/src/application/gui/menu/locations/option_button_in_menu.h
+++ b/src/application/gui/menu/locations/option_button_in_menu.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "augs/ensure.h"
 #include "augs/templates/hash_fwd.h"
 

--- a/src/application/gui/menu/menu_root.h
+++ b/src/application/gui/menu/menu_root.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "application/gui/menu/menu_element_location.h"
 #include "application/gui/menu/option_button.h"
 #include "augs/gui/dereferenced_location.h"

--- a/src/application/gui/server_list_entry.h
+++ b/src/application/gui/server_list_entry.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include "augs/network/network_types.h"
 #include "application/masterserver/server_heartbeat.h"
 #include "application/masterserver/masterserver_client.h"

--- a/src/application/gui/settings_gui.cpp
+++ b/src/application/gui/settings_gui.cpp
@@ -1,3 +1,5 @@
+#include <cstddef>
+#include <cstdint>
 #include <cstring>
 #include <thread>
 

--- a/src/application/gui/start_server_gui.cpp
+++ b/src/application/gui/start_server_gui.cpp
@@ -1,3 +1,4 @@
+#include <cstdint>
 #include "application/gui/start_server_gui.h"
 
 #include "augs/misc/imgui/imgui_control_wrappers.h"

--- a/src/application/main/auth_providers.h
+++ b/src/application/main/auth_providers.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include "application/main/auth_provider_type.h"
 #include "augs/misc/mutex.h"
 

--- a/src/application/main/game_frame_buffer.h
+++ b/src/application/main/game_frame_buffer.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <mutex>
 #include <atomic>
 #include <condition_variable>

--- a/src/application/main/miniature_generator.cpp
+++ b/src/application/main/miniature_generator.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "application/main/miniature_generator.h"
 #include "augs/log.h"
 

--- a/src/application/main/miniature_generator.h
+++ b/src/application/main/miniature_generator.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "augs/filesystem/path_declaration.h"
 #include "augs/math/camera_cone.h"
 #include "augs/graphics/renderer.h"

--- a/src/application/main/nat_traversal_details_window.h
+++ b/src/application/main/nat_traversal_details_window.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "augs/log_path_getters.h"
 #include "augs/filesystem/file.h"
 #include "application/setups/debugger/detail/maybe_different_colors.h"

--- a/src/application/main/release_flags.h
+++ b/src/application/main/release_flags.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "augs/misc/machine_entropy.h"
 
 struct ImGuiIO;

--- a/src/application/main/self_updater.cpp
+++ b/src/application/main/self_updater.cpp
@@ -1,3 +1,4 @@
+#include <cstdint>
 #if PLATFORM_UNIX
 #include <csignal>
 #endif

--- a/src/application/masterserver/gameserver_command_readwrite.h
+++ b/src/application/masterserver/gameserver_command_readwrite.h
@@ -1,4 +1,6 @@
 #pragma once
+#include <cstddef>
+#include <cstdint>
 #include "application/masterserver/gameserver_commands.h"
 
 inline std::optional<uint64_t> read_ping_response(const uint8_t* const packet_buffer, const std::size_t packet_bytes) {

--- a/src/application/masterserver/gameserver_commands.h
+++ b/src/application/masterserver/gameserver_commands.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include "3rdparty/yojimbo/netcode/netcode.h"
 #include "application/masterserver/nat_traversal_step.h"
 

--- a/src/application/masterserver/masterserver.cpp
+++ b/src/application/masterserver/masterserver.cpp
@@ -1,3 +1,5 @@
+#include <cstddef>
+#include <cstdint>
 #if PLATFORM_UNIX
 #include <csignal>
 #endif

--- a/src/application/masterserver/masterserver_client.h
+++ b/src/application/masterserver/masterserver_client.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 
 enum class server_type : uint8_t {
 	NATIVE,

--- a/src/application/masterserver/masterserver_requests.h
+++ b/src/application/masterserver/masterserver_requests.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include "application/masterserver/masterserver.h"
 #include "augs/readwrite/memory_stream_declaration.h"
 #include "augs/readwrite/memory_stream.h"

--- a/src/application/masterserver/nat_traversal_step.h
+++ b/src/application/masterserver/nat_traversal_step.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 
 #include "application/masterserver/nat_traversal_step_payload.h"
 #include "augs/network/port_type.h"

--- a/src/application/masterserver/nat_traversal_step_payload.h
+++ b/src/application/masterserver/nat_traversal_step_payload.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 
 using nat_session_guid_type = double;
 

--- a/src/application/masterserver/netcode_address_hash.h
+++ b/src/application/masterserver/netcode_address_hash.h
@@ -1,4 +1,6 @@
 #pragma once
+#include <cstddef>
+#include <cstdint>
 #include <cstring>
 #include <unordered_map>
 #include "augs/templates/hash_templates.h"

--- a/src/application/masterserver/server_heartbeat.h
+++ b/src/application/masterserver/server_heartbeat.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include "game/modes/all_mode_includes.h"
 #include "3rdparty/yojimbo/netcode/netcode.h"
 #include "application/nat/nat_type.h"

--- a/src/application/masterserver/server_list_entry_json.h
+++ b/src/application/masterserver/server_list_entry_json.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include "application/masterserver/server_heartbeat.h"
 
 struct server_list_entry_json {

--- a/src/application/masterserver/signalling_server.h
+++ b/src/application/masterserver/signalling_server.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include <nlohmann/json.hpp>
 #include "rtc/rtc.hpp"
 

--- a/src/application/nat/nat_detection_session.cpp
+++ b/src/application/nat/nat_detection_session.cpp
@@ -1,3 +1,5 @@
+#include <cstddef>
+#include <cstdint>
 #include <random>
 #include <numeric>
 #include "application/nat/nat_detection_session.h"

--- a/src/application/nat/nat_detection_session.h
+++ b/src/application/nat/nat_detection_session.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include <functional>
 #include <optional>
 #include <future>

--- a/src/application/nat/nat_detection_settings.h
+++ b/src/application/nat/nat_detection_settings.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include <vector>
 #include "application/network/host_with_default_port.h"
 #include "augs/filesystem/path_declaration.h"

--- a/src/application/nat/nat_traversal_session.cpp
+++ b/src/application/nat/nat_traversal_session.cpp
@@ -1,3 +1,5 @@
+#include <cstddef>
+#include <cstdint>
 #include "augs/network/netcode_utils.h"
 #include "augs/network/netcode_sockets.h"
 

--- a/src/application/nat/nat_traversal_session.h
+++ b/src/application/nat/nat_traversal_session.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include "augs/log.h"
 #include "augs/network/netcode_sockets.h"
 #include "application/nat/nat_type.h"

--- a/src/application/nat/nat_type.h
+++ b/src/application/nat/nat_type.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include "augs/network/port_type.h"
 #include "augs/graphics/rgba.h"
 

--- a/src/application/nat/stun_request.h
+++ b/src/application/nat/stun_request.h
@@ -1,4 +1,6 @@
 #pragma once
+#include <cstddef>
+#include <cstdint>
 #include "augs/misc/randomization.h"
 #include "augs/network/netcode_socket_includes.h"
 #include "application/nat/stun_request_structs.h"

--- a/src/application/nat/stun_request_structs.h
+++ b/src/application/nat/stun_request_structs.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include <array>
 
 // RFC 5389 Section 6 STUN Message Structure

--- a/src/application/network/client_adapter.h
+++ b/src/application/network/client_adapter.h
@@ -1,4 +1,6 @@
 #pragma once
+#include <cstddef>
+#include <cstdint>
 #include "augs/global_libraries.h"
 #include "application/network/network_adapters.h"
 #include "augs/network/network_simulator_settings.h"

--- a/src/application/network/client_adapter.hpp
+++ b/src/application/network/client_adapter.hpp
@@ -1,4 +1,6 @@
 #pragma once
+#include <cstddef>
+#include <cstdint>
 #include "application/network/network_adapters.hpp"
 #include "application/network/client_adapter.h"
 

--- a/src/application/network/client_platform_type.h
+++ b/src/application/network/client_platform_type.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 
 enum class client_platform_type : uint8_t {
 	UNKNOWN,

--- a/src/application/network/download_progress_message.h
+++ b/src/application/network/download_progress_message.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 
 struct download_progress_message {
 	uint8_t progress = 0;

--- a/src/application/network/net_message_readwrite.h
+++ b/src/application/network/net_message_readwrite.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 
 template <class T>
 constexpr bool is_block_message_v = std::is_base_of_v<only_block_message, T>;

--- a/src/application/network/net_message_translation.h
+++ b/src/application/network/net_message_translation.h
@@ -1,4 +1,6 @@
 #pragma once
+#include <cstddef>
+#include <cstdint>
 #include "augs/readwrite/memory_stream.h"
 #include "augs/misc/serialization_buffers.h"
 #include "augs/misc/compress.h"

--- a/src/application/network/net_serialize.h
+++ b/src/application/network/net_serialize.h
@@ -1,4 +1,6 @@
 #pragma once
+#include <cstddef>
+#include <cstdint>
 #include "3rdparty/yojimbo/serialize/serialize.h"
 #include "augs/log.h"
 #include "augs/readwrite/byte_readwrite_traits.h"

--- a/src/application/network/net_solvable_stream.h
+++ b/src/application/network/net_solvable_stream.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 
 template <class V>
 constexpr bool never_changes_in_game = is_one_of_v<V,

--- a/src/application/network/network_adapters.cpp
+++ b/src/application/network/network_adapters.cpp
@@ -1,3 +1,6 @@
+#include <cstring>
+#include <cstddef>
+#include <cstdint>
 #include "application/network/address_utils.h"
 #include "application/network/server_adapter.h"
 #include "application/network/client_adapter.h"

--- a/src/application/network/network_adapters.hpp
+++ b/src/application/network/network_adapters.hpp
@@ -1,4 +1,6 @@
 #pragma once
+#include <cstddef>
+#include <cstdint>
 #include "application/network/network_adapters.h"
 #include "augs/enums/callback_result.h"
 #include "augs/templates/traits/function_traits.h"

--- a/src/application/network/network_common.h
+++ b/src/application/network/network_common.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include "application/arena/arena_handle.h"
 #include "game/modes/all_mode_includes.h"
 

--- a/src/application/network/network_messages.h
+++ b/src/application/network/network_messages.h
@@ -1,4 +1,6 @@
 #pragma once
+#include <cstddef>
+#include <cstdint>
 #include "3rdparty/yojimbo/include/yojimbo.h"
 #undef write_bytes
 #undef read_bytes

--- a/src/application/network/requested_client_settings.h
+++ b/src/application/network/requested_client_settings.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include "augs/network/network_types.h"
 #include "augs/misc/constant_size_string.h"
 #include "application/setups/client/client_vars.h"

--- a/src/application/network/server_adapter.h
+++ b/src/application/network/server_adapter.h
@@ -1,4 +1,6 @@
 #pragma once
+#include <cstddef>
+#include <cstdint>
 #include <functional>
 #include "augs/global_libraries.h"
 #include "application/network/network_adapters.h"

--- a/src/application/network/server_adapter.hpp
+++ b/src/application/network/server_adapter.hpp
@@ -1,4 +1,6 @@
 #pragma once
+#include <cstddef>
+#include <cstdint>
 #include "augs/log.h"
 #include "application/network/network_adapters.hpp"
 #include "application/network/server_adapter.h"

--- a/src/application/network/server_step_entropy.h
+++ b/src/application/network/server_step_entropy.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include "augs/templates/logically_empty.h"
 #include "game/modes/mode_entropy.h"
 

--- a/src/application/network/simulation_receiver.h
+++ b/src/application/network/simulation_receiver.h
@@ -1,4 +1,6 @@
 #pragma once
+#include <cstddef>
+#include <cstdint>
 #include <unordered_set>
 
 #include "augs/log.h"

--- a/src/application/session_profiler.h
+++ b/src/application/session_profiler.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "augs/misc/profiler_mixin.h"
 #include "augs/texture_atlas/atlas_profiler.h"
 

--- a/src/application/setups/client/arena_downloading_session.h
+++ b/src/application/setups/client/arena_downloading_session.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <functional>
 #include <unordered_map>
 #include <vector>

--- a/src/application/setups/client/bandwidth_monitor.h
+++ b/src/application/setups/client/bandwidth_monitor.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 
 #include <atomic>
 #include <queue>

--- a/src/application/setups/client/client_handle_payload.hpp
+++ b/src/application/setups/client/client_handle_payload.hpp
@@ -1,4 +1,6 @@
 #pragma once
+#include <cstddef>
+#include <cstdint>
 #include "application/arena/choose_arena.h"
 
 using initial_snapshot_payload = full_arena_snapshot_payload<false>;

--- a/src/application/setups/client/client_setup.cpp
+++ b/src/application/setups/client/client_setup.cpp
@@ -1,3 +1,4 @@
+#include <cstdint>
 #include "augs/misc/pool/pool_io.hpp"
 #include "augs/misc/imgui/imgui_scope_wrappers.h"
 #include "augs/misc/imgui/imgui_control_wrappers.h"

--- a/src/application/setups/client/client_setup.h
+++ b/src/application/setups/client/client_setup.h
@@ -1,4 +1,6 @@
 #pragma once
+#include <cstddef>
+#include <cstdint>
 #include "augs/misc/future.h"
 #include "augs/math/camera_cone.h"
 #include "game/detail/render_layer_filter.h"

--- a/src/application/setups/client/client_vars.h
+++ b/src/application/setups/client/client_vars.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include <string>
 #include "augs/network/network_simulator_settings.h"
 #include "augs/filesystem/path_declaration.h"

--- a/src/application/setups/client/demo_file_meta.h
+++ b/src/application/setups/client/demo_file_meta.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include "hypersomnia_version.h"
 #include "augs/misc/constant_size_string.h"
 #include "augs/network/network_types.h"

--- a/src/application/setups/client/direct_file_download.h
+++ b/src/application/setups/client/direct_file_download.h
@@ -1,4 +1,6 @@
 #pragma once
+#include <cstddef>
+#include <cstdint>
 #include "application/setups/server/file_chunk_packet.h"
 #include "augs/misc/randomization.h"
 

--- a/src/application/setups/client/direct_file_download.hpp
+++ b/src/application/setups/client/direct_file_download.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include "application/setups/client/direct_file_download.h"
 
 direct_file_download::direct_file_download(

--- a/src/application/setups/client/https_file_downloader.cpp
+++ b/src/application/setups/client/https_file_downloader.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "application/setups/client/https_file_downloader.h"
 #include "augs/misc/httplib_utils.h"
 #include "application/detail_file_paths.h"

--- a/src/application/setups/client/https_file_downloader.h
+++ b/src/application/setups/client/https_file_downloader.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <thread>
 #include <vector>
 #include <string>

--- a/src/application/setups/client/https_file_uploader.cpp
+++ b/src/application/setups/client/https_file_uploader.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "application/setups/client/https_file_uploader.h"
 #include "augs/misc/httplib_utils.h"
 #include "application/detail_file_paths.h"

--- a/src/application/setups/client/https_file_uploader.h
+++ b/src/application/setups/client/https_file_uploader.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <thread>
 #include <vector>
 #include <string>

--- a/src/application/setups/debugger/commands/change_grouping_command.cpp
+++ b/src/application/setups/debugger/commands/change_grouping_command.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "application/setups/debugger/commands/change_grouping_command.h"
 #include "application/setups/debugger/debugger_folder.h"
 #include "application/setups/debugger/debugger_selection_groups.hpp"

--- a/src/application/setups/debugger/commands/change_grouping_command.h
+++ b/src/application/setups/debugger/commands/change_grouping_command.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <vector>
 #include <string>
 

--- a/src/application/setups/debugger/commands/change_property_command.cpp
+++ b/src/application/setups/debugger/commands/change_property_command.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "augs/enums/callback_result.h"
 
 #include "game/cosmos/typed_entity_handle.h"

--- a/src/application/setups/debugger/debugger_player.cpp
+++ b/src/application/setups/debugger/debugger_player.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "application/setups/debugger/debugger_player.h"
 #include "application/setups/debugger/debugger_folder.h"
 #include "application/setups/debugger/debugger_player.hpp"

--- a/src/application/setups/debugger/debugger_player.h
+++ b/src/application/setups/debugger/debugger_player.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <memory>
 #include <map>
 #include "augs/misc/timing/fixed_delta_timer.h"

--- a/src/application/setups/debugger/debugger_selection_groups.cpp
+++ b/src/application/setups/debugger/debugger_selection_groups.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "augs/string/typesafe_sprintf.h"
 #include "application/setups/debugger/debugger_selection_groups.h"
 #include "game/cosmos/cosmos.h"

--- a/src/application/setups/debugger/debugger_selection_groups.h
+++ b/src/application/setups/debugger/debugger_selection_groups.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <unordered_set>
 #include <vector>
 

--- a/src/application/setups/debugger/debugger_selection_groups.hpp
+++ b/src/application/setups/debugger/debugger_selection_groups.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "application/setups/debugger/debugger_selection_groups.h"
 
 template <class C, class F>

--- a/src/application/setups/debugger/debugger_setup.cpp
+++ b/src/application/setups/debugger/debugger_setup.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "augs/log.h"
 #include "augs/drawing/drawing.hpp"
 #include "augs/log_path_getters.h"

--- a/src/application/setups/debugger/debugger_setup.h
+++ b/src/application/setups/debugger/debugger_setup.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <future>
 
 #include "augs/templates/wrap_templates.h"

--- a/src/application/setups/debugger/debugger_setup.hpp
+++ b/src/application/setups/debugger/debugger_setup.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "application/setups/debugger/debugger_setup.h"
 #include "application/setups/debugger/detail/make_command_from_selections.h"
 #include "view/rendering_scripts/for_each_iconed_entity.h"

--- a/src/application/setups/debugger/gui/debugger_fae_gui.cpp
+++ b/src/application/setups/debugger/gui/debugger_fae_gui.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #define INCLUDE_TYPES_IN 1
 
 #include "game/cosmos/cosmos.h"

--- a/src/application/setups/debugger/gui/debugger_go_to_gui.cpp
+++ b/src/application/setups/debugger/gui/debugger_go_to_gui.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "augs/log.h"
 #include "application/setups/debugger/gui/debugger_go_to_gui.h"
 

--- a/src/application/setups/debugger/gui/debugger_history_gui.cpp
+++ b/src/application/setups/debugger/gui/debugger_history_gui.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "augs/templates/history.hpp"
 #include "augs/misc/imgui/imgui_utils.h"
 #include "augs/misc/imgui/imgui_control_wrappers.h"

--- a/src/application/setups/debugger/gui/debugger_player_gui.cpp
+++ b/src/application/setups/debugger/gui/debugger_player_gui.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "application/setups/debugger/gui/debugger_player_gui.h"
 #include "application/setups/debugger/debugger_player.h"
 #include "application/setups/debugger/debugger_command_input.h"

--- a/src/application/setups/debugger/gui/debugger_selection_groups_gui.cpp
+++ b/src/application/setups/debugger/gui/debugger_selection_groups_gui.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "augs/misc/imgui/imgui_utils.h"
 #include "augs/misc/imgui/imgui_scope_wrappers.h"
 #include "augs/misc/imgui/imgui_control_wrappers.h"

--- a/src/application/setups/debugger/gui/debugger_tab_gui.h
+++ b/src/application/setups/debugger/gui/debugger_tab_gui.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "augs/misc/imgui/imgui_control_wrappers.h"
 #include "augs/misc/imgui/addons/imguitabwindow/imguitabwindow.h"
 

--- a/src/application/setups/debugger/gui/debugger_tutorial_gui.cpp
+++ b/src/application/setups/debugger/gui/debugger_tutorial_gui.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include <thread>
 #include "application/setups/debugger/gui/debugger_tutorial_gui.h"
 #include "augs/templates/enum_introspect.h"

--- a/src/application/setups/debugger/property_debugger/fae/ex_on_buttons.h
+++ b/src/application/setups/debugger/property_debugger/fae/ex_on_buttons.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <string>
 #include "augs/misc/imgui/imgui_scope_wrappers.h"
 #include "game/cosmos/entity_flavour_id.h"

--- a/src/application/setups/debugger/property_debugger/fae/fae_tree.h
+++ b/src/application/setups/debugger/property_debugger/fae/fae_tree.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "augs/misc/imgui/imgui_control_wrappers.h"
 
 #include "game/organization/for_each_entity_type.h"

--- a/src/application/setups/debugger/property_debugger/widgets/non_standard_shape_widget.h
+++ b/src/application/setups/debugger/property_debugger/widgets/non_standard_shape_widget.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "view/viewables/images_in_atlas_map.h"
 #include "application/setups/debugger/property_debugger/tweaker_type.h"
 

--- a/src/application/setups/editor/commands/clone_nodes_command.cpp
+++ b/src/application/setups/editor/commands/clone_nodes_command.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "game/cosmos/entity_handle.h"
 #include "application/setups/editor/editor_setup.h"
 #include "application/setups/editor/editor_setup.hpp"

--- a/src/application/setups/editor/commands/clone_nodes_command.h
+++ b/src/application/setups/editor/commands/clone_nodes_command.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <vector>
 #include <string>
 

--- a/src/application/setups/editor/commands/create_layer_command.h
+++ b/src/application/setups/editor/commands/create_layer_command.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "application/setups/editor/commands/editor_command_meta.h"
 #include "application/setups/editor/nodes/editor_typed_node_id.h"
 #include "application/setups/editor/project/editor_layers.h"

--- a/src/application/setups/editor/commands/create_node_command.h
+++ b/src/application/setups/editor/commands/create_node_command.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "application/setups/editor/commands/editor_command_meta.h"
 #include "application/setups/editor/nodes/editor_typed_node_id.h"
 #include "application/setups/editor/project/editor_layers.h"

--- a/src/application/setups/editor/commands/create_resource_command.h
+++ b/src/application/setups/editor/commands/create_resource_command.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "application/setups/editor/commands/editor_command_meta.h"
 #include "application/setups/editor/resources/editor_typed_resource_id.h"
 #include "application/setups/editor/project/editor_layers.h"

--- a/src/application/setups/editor/commands/reorder_layers_command.h
+++ b/src/application/setups/editor/commands/reorder_layers_command.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "application/setups/editor/commands/editor_command_meta.h"
 #include "application/setups/editor/project/editor_layers.h"
 #include "application/setups/editor/project/editor_layers.h"

--- a/src/application/setups/editor/commands/reorder_layers_command.hpp
+++ b/src/application/setups/editor/commands/reorder_layers_command.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "application/setups/editor/commands/reorder_layers_command.h"
 #include "augs/templates/reversion_wrapper.h"
 

--- a/src/application/setups/editor/commands/reorder_nodes_command.h
+++ b/src/application/setups/editor/commands/reorder_nodes_command.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "application/setups/editor/commands/editor_command_meta.h"
 #include "application/setups/editor/nodes/editor_typed_node_id.h"
 #include "application/setups/editor/project/editor_layers.h"

--- a/src/application/setups/editor/commands/reorder_nodes_command.hpp
+++ b/src/application/setups/editor/commands/reorder_nodes_command.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "application/setups/editor/commands/reorder_nodes_command.h"
 #include "augs/templates/reversion_wrapper.h"
 #include "application/setups/editor/commands/create_layer_command.hpp"

--- a/src/application/setups/editor/editor_filesystem.h
+++ b/src/application/setups/editor/editor_filesystem.h
@@ -1,4 +1,6 @@
 #pragma once
+#include <cstddef>
+#include <cstdint>
 #include <map>
 #include "augs/filesystem/directory.h"
 #include "augs/templates/reversion_wrapper.h"

--- a/src/application/setups/editor/editor_filesystem_node_type.h
+++ b/src/application/setups/editor/editor_filesystem_node_type.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include "view/asset_funcs.h"
 
 enum class editor_filesystem_node_type : uint8_t {

--- a/src/application/setups/editor/editor_rebuild_game_mode.hpp
+++ b/src/application/setups/editor/editor_rebuild_game_mode.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include "augs/templates/remove_cref.h"
 #include "test_scenes/test_scene_flavours.h"
 #include "game/modes/all_mode_includes.h"

--- a/src/application/setups/editor/editor_rebuild_node.hpp
+++ b/src/application/setups/editor/editor_rebuild_node.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include "application/setups/editor/to_game_effect.hpp"
 #include "augs/misc/enum/enum_bitset.h"
 #include "view/audiovisual_state/systems/legacy_light_mults.h"

--- a/src/application/setups/editor/editor_rebuild_prefab_nodes.hpp
+++ b/src/application/setups/editor/editor_rebuild_prefab_nodes.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include "augs/misc/pool/pool_allocate.h"
 #include "augs/templates/traits/has_rotation.h"
 #include "augs/templates/traits/has_size.h"

--- a/src/application/setups/editor/editor_setup.cpp
+++ b/src/application/setups/editor/editor_setup.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "game/cosmos/logic_step.h"
 #include "application/setups/debugger/property_debugger/widgets/asset_sane_default_provider.h"
 #include "game/organization/all_messages_includes.h"

--- a/src/application/setups/editor/editor_setup.h
+++ b/src/application/setups/editor/editor_setup.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <optional>
 #include "augs/misc/timing/fixed_delta_timer.h"
 #include "augs/math/camera_cone.h"

--- a/src/application/setups/editor/editor_setup_imgui.cpp
+++ b/src/application/setups/editor/editor_setup_imgui.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "game/cosmos/logic_step.h"
 #include "game/organization/all_messages_includes.h"
 

--- a/src/application/setups/editor/gui/editor_filesystem_gui.cpp
+++ b/src/application/setups/editor/gui/editor_filesystem_gui.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "augs/templates/history.hpp"
 #include "augs/misc/imgui/imgui_utils.h"
 #include "augs/misc/imgui/imgui_control_wrappers.h"

--- a/src/application/setups/editor/gui/editor_history_gui.cpp
+++ b/src/application/setups/editor/gui/editor_history_gui.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "application/setups/editor/gui/editor_history_gui.h"
 #include "application/setups/editor/editor_history.h"
 #include "application/setups/editor/editor_setup.h"

--- a/src/application/setups/editor/gui/editor_inspector_gui.cpp
+++ b/src/application/setups/editor/gui/editor_inspector_gui.cpp
@@ -1,3 +1,5 @@
+#include <cstddef>
+#include <cstdint>
 #include "augs/templates/enum_introspect.h"
 #include "augs/templates/history.hpp"
 #include "application/setups/editor/editor_setup.hpp"

--- a/src/application/setups/editor/gui/editor_inspector_gui.h
+++ b/src/application/setups/editor/gui/editor_inspector_gui.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "augs/misc/imgui/standard_window_mixin.h"
 #include "application/setups/editor/nodes/editor_node_id.h"
 #include "application/setups/editor/resources/editor_resource_id.h"

--- a/src/application/setups/editor/gui/editor_layers_gui.cpp
+++ b/src/application/setups/editor/gui/editor_layers_gui.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "augs/templates/history.hpp"
 #include "augs/misc/imgui/imgui_utils.h"
 #include "augs/misc/imgui/imgui_control_wrappers.h"

--- a/src/application/setups/editor/gui/widgets/inspectable_with_icon.h
+++ b/src/application/setups/editor/gui/widgets/inspectable_with_icon.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 
 namespace editor_widgets {
 	template <class F>

--- a/src/application/setups/editor/gui/widgets/layer_chooser.h
+++ b/src/application/setups/editor/gui/widgets/layer_chooser.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include <vector>
 #include <optional>
 #include "augs/filesystem/file.h"

--- a/src/application/setups/editor/gui/widgets/node_chooser.h
+++ b/src/application/setups/editor/gui/widgets/node_chooser.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include <vector>
 #include <optional>
 #include "augs/filesystem/file.h"

--- a/src/application/setups/editor/gui/widgets/resource_chooser.h
+++ b/src/application/setups/editor/gui/widgets/resource_chooser.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include <vector>
 #include <optional>
 #include "augs/filesystem/file.h"

--- a/src/application/setups/editor/nodes/editor_marker_node_editable.h
+++ b/src/application/setups/editor/nodes/editor_marker_node_editable.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include "application/setups/editor/resources/editor_particle_effect.h"
 #include "application/setups/editor/resources/editor_sound_effect.h"
 #include "application/setups/editor/nodes/editor_typed_node_id.h"

--- a/src/application/setups/editor/nodes/editor_node_base.h
+++ b/src/application/setups/editor/nodes/editor_node_base.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include "game/cosmos/entity_id.h"
 #include "application/setups/editor/nodes/editor_typed_node_id.h"
 #include "application/setups/editor/resources/editor_typed_resource_id.h"

--- a/src/application/setups/editor/nodes/editor_node_id.h
+++ b/src/application/setups/editor/nodes/editor_node_id.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <compare>
 #include "augs/templates/type_in_list_id.h"
 #include "augs/misc/pool/pooled_object_id.h"

--- a/src/application/setups/editor/nodes/editor_node_pools.h
+++ b/src/application/setups/editor/nodes/editor_node_pools.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include <unordered_map>
 #include "augs/misc/pool/pool.h"
 #include "application/setups/editor/nodes/all_editor_node_types.h"

--- a/src/application/setups/editor/nodes/editor_prefab_node_editable.h
+++ b/src/application/setups/editor/nodes/editor_prefab_node_editable.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include "augs/graphics/rgba.h"
 #include "augs/math/vec2.h"
 

--- a/src/application/setups/editor/nodes/editor_sprite_node.h
+++ b/src/application/setups/editor/nodes/editor_sprite_node.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include "augs/math/vec2.h"
 #include "augs/math/transform.h"
 #include "application/setups/editor/nodes/editor_node_base.h"

--- a/src/application/setups/editor/official/create_official_resources.cpp
+++ b/src/application/setups/editor/official/create_official_resources.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "application/setups/editor/official/create_official_resources.h"
 #include "augs/string/string_templates.h"
 #include "augs/templates/type_map.h"

--- a/src/application/setups/editor/official/official_id_to_pool_id.h
+++ b/src/application/setups/editor/official/official_id_to_pool_id.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "application/setups/editor/resources/editor_typed_resource_id.h"
 #include "application/setups/editor/official/official_resource_id_enums.h"
 

--- a/src/application/setups/editor/project/editor_project.h
+++ b/src/application/setups/editor/project/editor_project.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "augs/misc/constant_size_string.h"
 #include "application/setups/editor/project/editor_project_meta.h"
 #include "application/setups/editor/project/editor_project_about.h"

--- a/src/application/setups/editor/project/editor_project.hpp
+++ b/src/application/setups/editor/project/editor_project.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "application/setups/editor/project/editor_project.h"
 
 template <class S, class Officials, class F>

--- a/src/application/setups/editor/project/editor_project_readwrite.cpp
+++ b/src/application/setups/editor/project/editor_project_readwrite.cpp
@@ -1,3 +1,5 @@
+#include <cstddef>
+#include <cstdint>
 #include <unordered_set>
 #include "augs/string/path_sanitization.h"
 #include "application/setups/editor/resources/editor_typed_resource_id.h"

--- a/src/application/setups/editor/resources/editor_ammunition_resource.h
+++ b/src/application/setups/editor/resources/editor_ammunition_resource.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include "augs/math/vec2.h"
 #include "game/cosmos/entity_flavour_id.h"
 #include "test_scenes/test_scene_flavour_ids.h"

--- a/src/application/setups/editor/resources/editor_explosive_resource.h
+++ b/src/application/setups/editor/resources/editor_explosive_resource.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include "augs/math/vec2.h"
 #include "game/cosmos/entity_flavour_id.h"
 #include "test_scenes/test_scene_flavour_ids.h"

--- a/src/application/setups/editor/resources/editor_firearm_resource.h
+++ b/src/application/setups/editor/resources/editor_firearm_resource.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include "augs/math/vec2.h"
 #include "game/cosmos/entity_flavour_id.h"
 #include "test_scenes/test_scene_flavour_ids.h"

--- a/src/application/setups/editor/resources/editor_game_mode_resource.h
+++ b/src/application/setups/editor/resources/editor_game_mode_resource.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include "application/setups/editor/resources/editor_typed_resource_id.h"
 #include "game/enums/faction_type.h"
 #include "augs/templates/type_in_list_id.h"

--- a/src/application/setups/editor/resources/editor_marker_resource.h
+++ b/src/application/setups/editor/resources/editor_marker_resource.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include "augs/math/vec2.h"
 #include "game/cosmos/entity_flavour_id.h"
 #include "game/enums/marker_type.h"

--- a/src/application/setups/editor/resources/editor_material_resource.h
+++ b/src/application/setups/editor/resources/editor_material_resource.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include "augs/math/vec2.h"
 #include "game/assets/ids/asset_ids.h"
 #include "application/setups/editor/resources/editor_typed_resource_id.h"

--- a/src/application/setups/editor/resources/editor_melee_resource.h
+++ b/src/application/setups/editor/resources/editor_melee_resource.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include "augs/math/vec2.h"
 #include "game/cosmos/entity_flavour_id.h"
 #include "test_scenes/test_scene_flavour_ids.h"

--- a/src/application/setups/editor/resources/editor_resource_id.h
+++ b/src/application/setups/editor/resources/editor_resource_id.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <compare>
 #include "augs/templates/type_in_list_id.h"
 #include "augs/misc/pool/pooled_object_id.h"

--- a/src/application/setups/editor/resources/editor_sound_effect.h
+++ b/src/application/setups/editor/resources/editor_sound_effect.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include "application/setups/editor/resources/editor_typed_resource_id.h"
 #include "augs/audio/distance_model.h"
 #include "augs/math/declare_math.h"

--- a/src/application/setups/editor/resources/editor_sound_resource.h
+++ b/src/application/setups/editor/resources/editor_sound_resource.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include "application/setups/editor/resources/editor_pathed_resource.h"
 #include "application/setups/editor/resources/editor_sound_effect.h"
 

--- a/src/application/setups/editor/resources/editor_sprite_resource.h
+++ b/src/application/setups/editor/resources/editor_sprite_resource.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include "application/setups/editor/resources/editor_pathed_resource.h"
 #include "view/viewables/ad_hoc_in_atlas_map.h"
 

--- a/src/application/setups/editor/resources/editor_tool_resource.h
+++ b/src/application/setups/editor/resources/editor_tool_resource.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include "augs/math/vec2.h"
 #include "game/cosmos/entity_flavour_id.h"
 #include "test_scenes/test_scene_flavour_ids.h"

--- a/src/application/setups/editor/resources/editor_typed_resource_id.h
+++ b/src/application/setups/editor/resources/editor_typed_resource_id.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "augs/misc/pool/pooled_object_id.h"
 #include "application/setups/editor/resources/editor_resource_id.h"
 #include "augs/ensure.h"

--- a/src/application/setups/editor/resources/editor_wandering_pixels_resource.h
+++ b/src/application/setups/editor/resources/editor_wandering_pixels_resource.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include "augs/math/vec2.h"
 #include "game/cosmos/entity_flavour_id.h"
 #include "test_scenes/test_scene_flavour_ids.h"

--- a/src/application/setups/editor/selector/editor_selection_groups_gui.cpp
+++ b/src/application/setups/editor/selector/editor_selection_groups_gui.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "augs/misc/imgui/imgui_utils.h"
 #include "augs/misc/imgui/imgui_scope_wrappers.h"
 #include "augs/misc/imgui/imgui_control_wrappers.h"

--- a/src/application/setups/server/chat_structs.h
+++ b/src/application/setups/server/chat_structs.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include "augs/misc/constant_size_string.h"
 #include "augs/network/network_types.h"
 #include "game/modes/mode_player_id.h"

--- a/src/application/setups/server/file_chunk_packet.h
+++ b/src/application/setups/server/file_chunk_packet.h
@@ -1,4 +1,6 @@
 #pragma once
+#include <cstddef>
+#include <cstdint>
 
 #define NETCODE_AUXILIARY_COMMAND_PACKET 200
 

--- a/src/application/setups/server/net_statistics_update.h
+++ b/src/application/setups/server/net_statistics_update.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 
 struct net_statistics_entry {
 	uint8_t ping;

--- a/src/application/setups/server/request_arena_file_download.h
+++ b/src/application/setups/server/request_arena_file_download.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include "augs/misc/secure_hash.h"
 #include "application/setups/server/file_chunk_packet.h"
 

--- a/src/application/setups/server/server_client_state.h
+++ b/src/application/setups/server/server_client_state.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include "application/setups/server/server_vars.h"
 #include "augs/network/jitter_buffer.h"
 #include "augs/network/network_types.h"

--- a/src/application/setups/server/server_handle_payload.hpp
+++ b/src/application/setups/server/server_handle_payload.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 
 template <class T, class F>
 message_handler_result server_setup::handle_payload(

--- a/src/application/setups/server/server_nat_traversal.cpp
+++ b/src/application/setups/server/server_nat_traversal.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "application/masterserver/netcode_address_hash.h"
 #include "application/setups/server/server_nat_traversal.h"
 #include "application/nat/stun_session.h"

--- a/src/application/setups/server/server_nat_traversal.h
+++ b/src/application/setups/server/server_nat_traversal.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <unordered_map>
 #include "application/nat/stun_session.h"
 #include "application/nat/nat_detection_settings.h"

--- a/src/application/setups/server/server_setup.cpp
+++ b/src/application/setups/server/server_setup.cpp
@@ -1,3 +1,5 @@
+#include <cstddef>
+#include <cstdint>
 #include "augs/misc/date_time.h"
 #include "augs/misc/pool/pool_io.hpp"
 #include "augs/misc/imgui/imgui_scope_wrappers.h"

--- a/src/application/setups/server/server_setup.h
+++ b/src/application/setups/server/server_setup.h
@@ -1,4 +1,6 @@
 #pragma once
+#include <cstddef>
+#include <cstdint>
 #include <future>
 #include "application/masterserver/netcode_address_hash.h"
 #include "augs/math/camera_cone.h"

--- a/src/application/setups/server/server_vars.h
+++ b/src/application/setups/server/server_vars.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include <string>
 #include "augs/network/network_simulator_settings.h"
 #include "augs/misc/constant_size_string.h"

--- a/src/application/setups/server/server_webhook_vars.h
+++ b/src/application/setups/server/server_webhook_vars.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include "augs/network/network_types.h"
 
 struct server_webhook_vars {

--- a/src/application/setups/server/webhooks.h
+++ b/src/application/setups/server/webhooks.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #define RAPIDJSON_HAS_STDSTRING 1
 
 #include "3rdparty/include_httplib.h"

--- a/src/application/setups/test_scene_setup.cpp
+++ b/src/application/setups/test_scene_setup.cpp
@@ -1,3 +1,4 @@
+#include <cstdint>
 #include "game/cosmos/logic_step.h"
 #include "game/organization/all_messages_includes.h"
 

--- a/src/application/setups/test_scene_setup.h
+++ b/src/application/setups/test_scene_setup.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include <optional>
 #include "augs/misc/timing/fixed_delta_timer.h"
 #include "augs/math/camera_cone.h"

--- a/src/application/tests_of_traits.cpp
+++ b/src/application/tests_of_traits.cpp
@@ -1,3 +1,5 @@
+#include <cstddef>
+#include <cstdint>
 #define INCLUDE_TYPES_IN 1
 #include <fstream>
 #include "augs/filesystem/path.h"

--- a/src/application/web_daemon/session_report.cpp
+++ b/src/application/web_daemon/session_report.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "augs/build_settings/setting_build_http_daemon.h"
 #include "session_report.h"
 

--- a/src/augs/audio/audio_backend.cpp
+++ b/src/augs/audio/audio_backend.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "augs/audio/audio_backend.h"
 #include "augs/log.h"
 #include "augs/audio/sound_source.h"

--- a/src/augs/audio/audio_backend.h
+++ b/src/augs/audio/audio_backend.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "augs/audio/sound_source.h"
 #include "augs/audio/sound_sizes.h"
 

--- a/src/augs/audio/audio_command_buffers.h
+++ b/src/augs/audio/audio_command_buffers.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <vector>
 #include <atomic>
 #include <mutex>

--- a/src/augs/audio/audio_commands.h
+++ b/src/augs/audio/audio_commands.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "augs/math/vec2.h"
 #include "augs/math/si_scaling.h"
 #include "augs/audio/sound_buffer.h"

--- a/src/augs/audio/audio_context.cpp
+++ b/src/augs/audio/audio_context.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "audio_context.h"
 
 #include "augs/audio/OpenAL_error.h"

--- a/src/augs/audio/audio_settings.h
+++ b/src/augs/audio/audio_settings.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include <string>
 
 enum class audio_output_mode {

--- a/src/augs/audio/sound_buffer.cpp
+++ b/src/augs/audio/sound_buffer.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "augs/log.h"
 
 #if BUILD_OPENAL

--- a/src/augs/audio/sound_buffer.h
+++ b/src/augs/audio/sound_buffer.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <vector>
 #include <optional>
 

--- a/src/augs/audio/sound_data.cpp
+++ b/src/augs/audio/sound_data.cpp
@@ -1,3 +1,5 @@
+#include <cstddef>
+#include <cstdint>
 #if PLATFORM_UNIX
 /* Necessary for some stuff in ogg library */
 #pragma GCC diagnostic ignored "-Wunused-variable"

--- a/src/augs/audio/sound_data.h
+++ b/src/augs/audio/sound_data.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include <vector>
 #include "augs/filesystem/path.h"
 #include "augs/templates/exception_templates.h"

--- a/src/augs/audio/sound_sizes.h
+++ b/src/augs/audio/sound_sizes.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 
 constexpr std::size_t SOUNDS_SOURCES_IN_POOL = 4000;
 

--- a/src/augs/audio/sound_source.cpp
+++ b/src/augs/audio/sound_source.cpp
@@ -1,3 +1,5 @@
+#include <cstddef>
+#include <cstdint>
 #define TRACE_PARAMETERS 0
 #define TRACE_CONSTRUCTORS_DESTRUCTORS 0
 #define Y_IS_Z 1

--- a/src/augs/audio/sound_source.h
+++ b/src/augs/audio/sound_source.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <array>
 #include <stdexcept>
 

--- a/src/augs/audio/sound_source_proxy.h
+++ b/src/augs/audio/sound_source_proxy.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "augs/audio/audio_renderer.h"
 #include "augs/audio/sound_source_proxy_id.h"
 

--- a/src/augs/drawing/polygon.h
+++ b/src/augs/drawing/polygon.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "augs/templates/algorithm_templates.h"
 #include "augs/math/vec2.h"
 #include "augs/misc/constant_size_vector.h"

--- a/src/augs/drawing/polygon.hpp
+++ b/src/augs/drawing/polygon.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "augs/drawing/polygon.h"
 #include "augs/texture_atlas/atlas_entry.h"
 #include "augs/drawing/drawing.h"

--- a/src/augs/ensure.cpp
+++ b/src/augs/ensure.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include <csignal>
 #include <functional>
 

--- a/src/augs/filesystem/find_path.h
+++ b/src/augs/filesystem/find_path.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "augs/string/typesafe_sprintf.h"
 #include "augs/filesystem/file.h"
 

--- a/src/augs/filesystem/path.h
+++ b/src/augs/filesystem/path.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "augs/filesystem/path_declaration.h"
 #include "augs/readwrite/byte_readwrite_declaration.h"
 #include "augs/string/string_templates.h"

--- a/src/augs/graphics/frame_num_type.h
+++ b/src/augs/graphics/frame_num_type.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 
 namespace augs {
 	using frame_num_type = std::size_t;

--- a/src/augs/graphics/pbo.cpp
+++ b/src/augs/graphics/pbo.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "pbo.h"
 #include "augs/log.h"
 #include "augs/graphics/OpenGL_includes.h"

--- a/src/augs/graphics/pbo.h
+++ b/src/augs/graphics/pbo.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "augs/math/vec2.h"
 #include "augs/templates/settable_as_current_mixin.h"
 #include "augs/graphics/texture.h"

--- a/src/augs/graphics/renderer.cpp
+++ b/src/augs/graphics/renderer.cpp
@@ -1,3 +1,5 @@
+#include <cstddef>
+#include <cstdint>
 #include "augs/ensure_rel.h"
 #include "augs/graphics/renderer.h"
 #include "3rdparty/imgui/imgui.h"

--- a/src/augs/graphics/renderer.h
+++ b/src/augs/graphics/renderer.h
@@ -1,4 +1,6 @@
 #pragma once
+#include <cstddef>
+#include <cstdint>
 #include "augs/math/vec2.h"
 #include "augs/templates/object_command.h"
 

--- a/src/augs/graphics/renderer_backend.cpp
+++ b/src/augs/graphics/renderer_backend.cpp
@@ -1,3 +1,5 @@
+#include <cstddef>
+#include <cstdint>
 #include "augs/log_direct.h"
 #include "augs/graphics/renderer_backend.h"
 #include "augs/graphics/OpenGL_includes.h"

--- a/src/augs/graphics/renderer_backend.h
+++ b/src/augs/graphics/renderer_backend.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <memory>
 #include "augs/graphics/renderer_command_enums.h"
 #include "augs/graphics/rgba.h"

--- a/src/augs/graphics/renderer_commands.h
+++ b/src/augs/graphics/renderer_commands.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include "augs/graphics/renderer_command_enums.h"
 #include "3rdparty/imgui/imgui.h"
 #include "augs/graphics/vertex.h"

--- a/src/augs/graphics/rgba.cpp
+++ b/src/augs/graphics/rgba.cpp
@@ -1,3 +1,4 @@
+#include <cstdint>
 #include <limits>
 #include <array>
 #include <algorithm>

--- a/src/augs/graphics/rgba.h
+++ b/src/augs/graphics/rgba.h
@@ -1,4 +1,6 @@
 #pragma once
+#include <cstddef>
+#include <cstdint>
 #include <array>
 #include <sstream>
 #include <algorithm>

--- a/src/augs/gui/bbcode.cpp
+++ b/src/augs/gui/bbcode.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include <algorithm>
 #include <cstring>
 #include <vector>

--- a/src/augs/gui/formatted_string.cpp
+++ b/src/augs/gui/formatted_string.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "augs/misc/mutex.h"
 #include "augs/log.h"
 

--- a/src/augs/gui/formatted_string.h
+++ b/src/augs/gui/formatted_string.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <string>
 #include <vector>
 

--- a/src/augs/gui/text/ui.cpp
+++ b/src/augs/gui/text/ui.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include <algorithm>
 #include "augs/gui/text/ui.h"
 #include "augs/window_framework/window.h"

--- a/src/augs/image/font.cpp
+++ b/src/augs/image/font.cpp
@@ -1,3 +1,5 @@
+#include <cstddef>
+#include <cstdint>
 #include <map>
 #include "augs/image/font.h"
 #include "augs/log.h"

--- a/src/augs/image/font.h
+++ b/src/augs/image/font.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <unordered_map>
 #include "augs/math/vec2.h"
 #include "augs/templates/exception_templates.h"

--- a/src/augs/image/image.cpp
+++ b/src/augs/image/image.cpp
@@ -1,3 +1,5 @@
+#include <cstddef>
+#include <cstdint>
 #include <cstring>
 
 #define BUILD_IMAGE 1

--- a/src/augs/log.cpp
+++ b/src/augs/log.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include <string>
 #include <thread>
 #include <mutex>

--- a/src/augs/log.h
+++ b/src/augs/log.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <vector>
 #include <cstring>
 

--- a/src/augs/math/convex_hull.h
+++ b/src/augs/math/convex_hull.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <vector>
 #include "augs/templates/algorithm_templates.h"
 

--- a/src/augs/math/transform.h
+++ b/src/augs/math/transform.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <type_traits>
 
 #include "augs/math/vec2.h"

--- a/src/augs/math/vec2.h
+++ b/src/augs/math/vec2.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "augs/math/repro_math.h"
 
 #include <string>

--- a/src/augs/misc/action_list/action_list.cpp
+++ b/src/augs/misc/action_list/action_list.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "action_list.h"
 #include "action.h"
 #include "augs/misc/timing/delta.h"

--- a/src/augs/misc/action_list/standard_actions.h
+++ b/src/augs/misc/action_list/standard_actions.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <functional>
 
 #include "augs/math/vec2.h"

--- a/src/augs/misc/async_response.h
+++ b/src/augs/misc/async_response.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <string>
 #include <unordered_map>
 #include <functional>

--- a/src/augs/misc/compress.cpp
+++ b/src/augs/misc/compress.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "augs/misc/compress.h"
 #include "3rdparty/lz4/lz4.c"
 #include "augs/log.h"

--- a/src/augs/misc/compress.h
+++ b/src/augs/misc/compress.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <vector>
 #include "augs/templates/exception_templates.h"
 

--- a/src/augs/misc/constant_size_string.h
+++ b/src/augs/misc/constant_size_string.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <array>
 #include <cstring>
 #include <string>

--- a/src/augs/misc/constant_size_vector.h
+++ b/src/augs/misc/constant_size_vector.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <array>
 #include <cstring>
 #include <iterator>

--- a/src/augs/misc/convex_partitioned_shape.h
+++ b/src/augs/misc/convex_partitioned_shape.h
@@ -1,4 +1,6 @@
 #pragma once
+#include <cstddef>
+#include <cstdint>
 #include "augs/math/vec2.h"
 #include "augs/math/transform.h"
 

--- a/src/augs/misc/convex_partitioned_shape.hpp
+++ b/src/augs/misc/convex_partitioned_shape.hpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "augs/misc/convex_partitioned_shape.h"
 
 template <

--- a/src/augs/misc/date_time.cpp
+++ b/src/augs/misc/date_time.cpp
@@ -41,14 +41,7 @@ augs::date_time::date_time(
 {
 }
 
-#if defined(__clang__) && defined(PLATFORM_UNIX) 
-augs::date_time::date_time(
-	const augs::file_time_type& tp
-) : 
-	date_time(std::chrono::time_point_cast<std::chrono::system_clock::duration>(std::chrono::file_clock::to_sys(tp))) 
-	{
-}
-#else
+#if PLATFORM_WINDOWS
 
 static time_t filetime_to_timet(FILETIME const& ft) {
     ULARGE_INTEGER ull;
@@ -64,7 +57,17 @@ augs::date_time::date_time(
 	std::memcpy(&ft, &input_filetime, sizeof(FILETIME));
 	t = filetime_to_timet(ft);
 }
-#endif
+
+#else // PLATFORM_WINDOWS
+
+augs::date_time::date_time(
+	const augs::file_time_type& tp
+) : 
+	date_time(std::chrono::time_point_cast<std::chrono::system_clock::duration>(std::chrono::file_clock::to_sys(tp))) 
+	{
+}
+
+#endif // PLATFORM_WINDOWS
 
 std::string augs::date_time::format_time_point_utc_iso8601(const std::chrono::system_clock::time_point& tp) {
 	// Convert system_clock::time_point to utc tm structure

--- a/src/augs/misc/date_time.cpp
+++ b/src/augs/misc/date_time.cpp
@@ -1,3 +1,4 @@
+#include <cstdint>
 #include <ctime>
 #include <iomanip>
 #include <sstream>

--- a/src/augs/misc/date_time.h
+++ b/src/augs/misc/date_time.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include <ctime>
 #include <string>
 #include <chrono>

--- a/src/augs/misc/enum/enum_array.h
+++ b/src/augs/misc/enum/enum_array.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <array>
 
 namespace augs {

--- a/src/augs/misc/enum/enum_bitset.h
+++ b/src/augs/misc/enum/enum_bitset.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <bitset>
 
 namespace augs {

--- a/src/augs/misc/enum/enum_boolset.h
+++ b/src/augs/misc/enum/enum_boolset.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <array>
 #include "augs/templates/constexpr_arithmetic.h"
 #include "augs/templates/algorithm_templates.h"

--- a/src/augs/misc/enum/enum_map.h
+++ b/src/augs/misc/enum/enum_map.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "augs/ensure.h"
 #include "augs/templates/maybe_const.h"
 #include "augs/templates/traits/is_comparable.h"

--- a/src/augs/misc/from_concave_polygon.h
+++ b/src/augs/misc/from_concave_polygon.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "3rdparty/polypartition/src/polypartition.h"
 #include "augs/graphics/vertex.h"
 #include "augs/drawing/polygon.h"

--- a/src/augs/misc/httplib_emscripten.h
+++ b/src/augs/misc/httplib_emscripten.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <emscripten/fetch.h>
 #include <string>
 #include <iostream>

--- a/src/augs/misc/imgui/imgui_control_wrappers.h
+++ b/src/augs/misc/imgui/imgui_control_wrappers.h
@@ -1,4 +1,6 @@
 #pragma once
+#include <cstddef>
+#include <cstdint>
 #include "3rdparty/imgui/imgui.h"
 #include "augs/string/typesafe_sprintf.h"
 

--- a/src/augs/misc/imgui/simple_popup.cpp
+++ b/src/augs/misc/imgui/simple_popup.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "augs/string/typesafe_sprintf.h"
 #include "augs/misc/imgui/imgui_control_wrappers.h"
 #include "augs/misc/imgui/simple_popup.h"

--- a/src/augs/misc/maybe_official_path.h
+++ b/src/augs/misc/maybe_official_path.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include "augs/filesystem/path.h"
 #include "all_paths.h"
 

--- a/src/augs/misc/measurements.h
+++ b/src/augs/misc/measurements.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <string>
 
 #include "augs/ensure.h"

--- a/src/augs/misc/pool/pool.h
+++ b/src/augs/misc/pool/pool.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <cstring>
 #include <optional>
 

--- a/src/augs/misc/pool/pool_allocate.h
+++ b/src/augs/misc/pool/pool_allocate.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "augs/misc/pool/pool.h"
 #include "augs/ensure_rel.h"
 

--- a/src/augs/misc/pool/pooled_object_id.h
+++ b/src/augs/misc/pool/pooled_object_id.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <sstream>
 #include "augs/templates/hash_templates.h"
 #include "augs/templates/hash_fwd.h"

--- a/src/augs/misc/profanity_filter.cpp
+++ b/src/augs/misc/profanity_filter.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include <unordered_set>
 #include "augs/misc/profanity_filter.h"
 #include "augs/misc/crazygames_profanities_list.h"

--- a/src/augs/misc/randomization.cpp
+++ b/src/augs/misc/randomization.cpp
@@ -1,3 +1,5 @@
+#include <cstddef>
+#include <cstdint>
 #include <random>
 
 #include "augs/math/repro_math.h"

--- a/src/augs/misc/randomization.h
+++ b/src/augs/misc/randomization.h
@@ -1,4 +1,6 @@
 #pragma once
+#include <cstddef>
+#include <cstdint>
 #include <vector>
 
 #include "augs/misc/randomization_declaration.h"

--- a/src/augs/misc/readable_bytesize.cpp
+++ b/src/augs/misc/readable_bytesize.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "readable_bytesize.h"
 #include "augs/string/typesafe_sprintf.h"
 

--- a/src/augs/misc/readable_bytesize.h
+++ b/src/augs/misc/readable_bytesize.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <string>
 
 std::string readable_bytesize(std::size_t bytes, const char* number_format = "%x");

--- a/src/augs/misc/secure_hash.cpp
+++ b/src/augs/misc/secure_hash.cpp
@@ -1,3 +1,5 @@
+#include <cstddef>
+#include <cstdint>
 #include <sstream>
 #include <iomanip>
 

--- a/src/augs/misc/secure_hash.h
+++ b/src/augs/misc/secure_hash.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include <vector>
 #include <cstddef>
 #include <string>

--- a/src/augs/misc/simple_id_pool.h
+++ b/src/augs/misc/simple_id_pool.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <optional>
 
 namespace augs {

--- a/src/augs/misc/simple_pair.h
+++ b/src/augs/misc/simple_pair.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "augs/templates/hash_templates.h"
 #include "augs/templates/can_stream.h"
 

--- a/src/augs/misc/timing/stepped_timing.h
+++ b/src/augs/misc/timing/stepped_timing.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include "augs/misc/timing/delta.h"
 #include "augs/pad_bytes.h"
 

--- a/src/augs/misc/to_hex_str.h
+++ b/src/augs/misc/to_hex_str.h
@@ -1,4 +1,6 @@
 #pragma once
+#include <cstddef>
+#include <cstdint>
 #include <string>
 #include <array>
 

--- a/src/augs/misc/trivially_copyable_tuple.h
+++ b/src/augs/misc/trivially_copyable_tuple.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "augs/templates/type_list.h"
 #include "augs/templates/constexpr_arithmetic.h"
 #include "augs/templates/folded_finders.h"

--- a/src/augs/misc/verify_token.hpp
+++ b/src/augs/misc/verify_token.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include <iostream>
 #include <sstream>
 #include <string>

--- a/src/augs/network/jitter_buffer.h
+++ b/src/augs/network/jitter_buffer.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <vector>
 
 namespace augs {

--- a/src/augs/network/netcode_sockets.h
+++ b/src/augs/network/netcode_sockets.h
@@ -1,4 +1,6 @@
 #pragma once
+#include <cstddef>
+#include <cstdint>
 #include "3rdparty/yojimbo/netcode/netcode.h"
 #include "augs/network/port_type.h"
 #include "augs/log.h"

--- a/src/augs/network/netcode_utils.h
+++ b/src/augs/network/netcode_utils.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include <string>
 #include "augs/network/netcode_sockets.h"
 #include "augs/network/network_types.h"

--- a/src/augs/network/port_type.h
+++ b/src/augs/network/port_type.h
@@ -1,3 +1,4 @@
 #pragma once
+#include <cstdint>
 
 using port_type = uint16_t;

--- a/src/augs/readwrite/byte_readwrite.h
+++ b/src/augs/readwrite/byte_readwrite.h
@@ -1,4 +1,6 @@
 #pragma once
+#include <cstddef>
+#include <cstdint>
 #include <type_traits>
 #include <vector>
 

--- a/src/augs/readwrite/byte_readwrite_declaration.h
+++ b/src/augs/readwrite/byte_readwrite_declaration.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include <cstddef>
 
 namespace augs {

--- a/src/augs/readwrite/delta_compression.h
+++ b/src/augs/readwrite/delta_compression.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <vector>
 #include "augs/templates/traits/triviality_traits.h"
 #include "augs/templates/get_index_type_for_size_of.h"

--- a/src/augs/readwrite/file_to_bytes.h
+++ b/src/augs/readwrite/file_to_bytes.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 
 namespace augs {
 	inline auto file_to_bytes(const path_type& path, std::vector<std::byte>& output) {

--- a/src/augs/readwrite/json_readwrite.h
+++ b/src/augs/readwrite/json_readwrite.h
@@ -1,4 +1,6 @@
 #pragma once
+#include <cstddef>
+#include <cstdint>
 #define RAPIDJSON_HAS_STDSTRING 1
 
 #include "augs/string/string_to_enum.h"

--- a/src/augs/readwrite/memory_stream.h
+++ b/src/augs/readwrite/memory_stream.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <vector>
 #include <algorithm>
 #include "augs/readwrite/memory_stream_declaration.h"

--- a/src/augs/readwrite/pointer_to_buffer.h
+++ b/src/augs/readwrite/pointer_to_buffer.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "augs/ensure_rel.h"
 
 namespace augs {

--- a/src/augs/readwrite/sane_max_size.h
+++ b/src/augs/readwrite/sane_max_size.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include "augs/network/network_types.h"
 #include "augs/templates/type_map.h"
 

--- a/src/augs/readwrite/to_bytes.h
+++ b/src/augs/readwrite/to_bytes.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "augs/readwrite/memory_stream.h"
 #include "augs/misc/constant_size_vector.h"
 #include "augs/readwrite/byte_readwrite_traits.h"

--- a/src/augs/string/first_free.h
+++ b/src/augs/string/first_free.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <string>
 
 namespace augs {

--- a/src/augs/string/path_sanitization.cpp
+++ b/src/augs/string/path_sanitization.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "augs/string/path_sanitization.h"
 #include "augs/network/network_types.h"
 #include "application/arena/arena_paths.h"

--- a/src/augs/string/pretty_print.h
+++ b/src/augs/string/pretty_print.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include "augs/templates/can_stream.h"
 #include "augs/string/get_type_name.h"
 #include "augs/templates/traits/is_optional.h"

--- a/src/augs/string/string_to_enum.h
+++ b/src/augs/string/string_to_enum.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <string>
 #include <unordered_map>
 

--- a/src/augs/string/typesafe_sprintf.h
+++ b/src/augs/string/typesafe_sprintf.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <string>
 #include <sstream>
 #include <utility>

--- a/src/augs/string/typesafe_sscanf.cpp
+++ b/src/augs/string/typesafe_sscanf.cpp
@@ -1,3 +1,4 @@
+#include <cstdint>
 #include "augs/string/typesafe_sscanf.h"
 
 bool is_more_recent(const std::string& next_version, const std::string& current_version) {

--- a/src/augs/string/typesafe_sscanf.h
+++ b/src/augs/string/typesafe_sscanf.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <string>
 #include <sstream>
 #include <utility>

--- a/src/augs/templates/algorithm_templates.h
+++ b/src/augs/templates/algorithm_templates.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <vector>
 #include <algorithm>
 #include <type_traits>

--- a/src/augs/templates/chrono_templates.h
+++ b/src/augs/templates/chrono_templates.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <chrono>
 #include <string>
 #include <tuple>

--- a/src/augs/templates/container_templates.h
+++ b/src/augs/templates/container_templates.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <algorithm>
 #include <iterator>
 #include <vector>

--- a/src/augs/templates/enum_introspect.h
+++ b/src/augs/templates/enum_introspect.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #ifndef ENUM_INTROSPECT_INCLUDED
 #define ENUM_INTROSPECT_INCLUDED 1
 #endif

--- a/src/augs/templates/filter_types.h
+++ b/src/augs/templates/filter_types.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <type_traits>
 #include "augs/templates/nth_type_in.h"
 #include "augs/templates/list_utils.h"

--- a/src/augs/templates/folded_finders.h
+++ b/src/augs/templates/folded_finders.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <type_traits>
 #include "augs/templates/always_false.h"
 

--- a/src/augs/templates/for_each_std_get.h
+++ b/src/augs/templates/for_each_std_get.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <type_traits>
 #include <tuple>
 #include <variant>

--- a/src/augs/templates/get_by_dynamic_id.h
+++ b/src/augs/templates/get_by_dynamic_id.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <tuple>
 #include <variant>
 #include <optional>

--- a/src/augs/templates/get_index_type_for_size_of.h
+++ b/src/augs/templates/get_index_type_for_size_of.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include <limits>
 
 #include "augs/templates/filter_types.h"

--- a/src/augs/templates/hash_templates.h
+++ b/src/augs/templates/hash_templates.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include "augs/misc/portable_hash.h"
 
 namespace augs {

--- a/src/augs/templates/in_order_of.h
+++ b/src/augs/templates/in_order_of.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 
 template <class T, class P, class Cmp, class F, class S>
 void in_order_of(T& container, P get_property, Cmp comparator, F order_callback, S& sorted_cache) {

--- a/src/augs/templates/introspection_utils/count_members.h
+++ b/src/augs/templates/introspection_utils/count_members.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "augs/pad_bytes.h"
 #include "augs/templates/introspect_declaration.h"
 

--- a/src/augs/templates/introspection_utils/rewrite_members.h
+++ b/src/augs/templates/introspection_utils/rewrite_members.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "augs/templates/introspect_declaration.h"
 #include "augs/templates/remove_cref.h"
 

--- a/src/augs/templates/introspection_utils/types_in.h
+++ b/src/augs/templates/introspection_utils/types_in.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <type_traits>
 #include "generated/introspectors.h"
 #include "augs/templates/traits/introspection_traits.h"

--- a/src/augs/templates/per_type.h
+++ b/src/augs/templates/per_type.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <tuple>
 
 #include "augs/templates/reversion_wrapper.h"

--- a/src/augs/templates/range_workers.h
+++ b/src/augs/templates/range_workers.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <vector>
 #include <thread>
 #include <atomic>

--- a/src/augs/templates/resize_no_init.h
+++ b/src/augs/templates/resize_no_init.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <type_traits>
 #include "augs/misc/declare_containers.h"
 

--- a/src/augs/templates/sequence_utils.h
+++ b/src/augs/templates/sequence_utils.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "augs/templates/identity_templates.h"
 
 template <size_t, class>

--- a/src/augs/templates/thread_pool.h
+++ b/src/augs/templates/thread_pool.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <vector>
 #include <thread>
 #include <mutex>

--- a/src/augs/templates/traits/function_traits.h
+++ b/src/augs/templates/traits/function_traits.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "augs/templates/nth_type_in.h"
 
 template <class T, class R, class... Args>

--- a/src/augs/templates/traits/is_enum_map.h
+++ b/src/augs/templates/traits/is_enum_map.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "augs/misc/declare_containers.h"
 
 template <class T>

--- a/src/augs/templates/traits/is_std_array.h
+++ b/src/augs/templates/traits/is_std_array.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <array>
 
 namespace augs {

--- a/src/augs/templates/type_in_list_id.h
+++ b/src/augs/templates/type_in_list_id.h
@@ -1,4 +1,6 @@
 #pragma once
+#include <cstddef>
+#include <cstdint>
 #include <utility>
 #include <compare>
 #include "augs/templates/type_list.h"

--- a/src/augs/templates/type_pair.h
+++ b/src/augs/templates/type_pair.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 
 template <class A, class B>
 struct type_pair {

--- a/src/augs/texture_atlas/atlas_profiler.h
+++ b/src/augs/texture_atlas/atlas_profiler.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "augs/misc/measurements.h"
 #include "augs/misc/profiler_mixin.h"
 #include "augs/math/vec2.h"

--- a/src/augs/texture_atlas/bake_fresh_atlas.cpp
+++ b/src/augs/texture_atlas/bake_fresh_atlas.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include <string>
 #include <sstream>
 #include <numeric>

--- a/src/augs/texture_atlas/bake_fresh_atlas.h
+++ b/src/augs/texture_atlas/bake_fresh_atlas.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <unordered_map>
 #include <chrono>
 

--- a/src/augs/window_framework/detail_xinput.h
+++ b/src/augs/window_framework/detail_xinput.h
@@ -1,3 +1,4 @@
+#include <cstdint>
 /** Opcode for xcb_input_raw_motion. */
 #define XCB_INPUT_RAW_MOTION 17
 

--- a/src/augs/window_framework/event.cpp
+++ b/src/augs/window_framework/event.cpp
@@ -1,3 +1,5 @@
+#include <cstring>
+#include <cstddef>
 #include "event.h"
 #include "augs/ensure.h"
 #include "augs/templates/traits/triviality_traits.h"

--- a/src/augs/window_framework/event.h
+++ b/src/augs/window_framework/event.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include <string>
 #include <sstream>
 #include <optional>

--- a/src/augs/window_framework/explorer_utils_winapi.hpp
+++ b/src/augs/window_framework/explorer_utils_winapi.hpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include <GLFW/glfw3.h>
 
 #define GLFW_EXPOSE_NATIVE_WIN32

--- a/src/augs/window_framework/pipe.h
+++ b/src/augs/window_framework/pipe.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 
 #if PLATFORM_WINDOWS
 #include <Windows.h>

--- a/src/augs/window_framework/platform_utils.cpp
+++ b/src/augs/window_framework/platform_utils.cpp
@@ -1,3 +1,4 @@
+#include <cstring>
 #include "augs/window_framework/platform_utils.h"
 #include "augs/string/string_templates.h"
 

--- a/src/augs/window_framework/window_x.cpp
+++ b/src/augs/window_framework/window_x.cpp
@@ -1,3 +1,6 @@
+#include <cstring>
+#include <cstddef>
+#include <cstdint>
 #include <thread>
 
 #include <unistd.h>

--- a/src/cmd_line_params.h
+++ b/src/cmd_line_params.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include "augs/filesystem/path.h"
 #include "augs/app_type.h"
 #include "augs/network/network_types.h"

--- a/src/fp_consistency_tests.cpp
+++ b/src/fp_consistency_tests.cpp
@@ -1,3 +1,5 @@
+#include <cstddef>
+#include <cstdint>
 #include "augs/math/repro_math.h"
 
 #include "augs/log.h"

--- a/src/game/assets/physical_material.h
+++ b/src/game/assets/physical_material.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include <string>
 #include <unordered_map>
 #include "game/assets/ids/asset_ids.h"

--- a/src/game/assets/recoil_player.cpp
+++ b/src/game/assets/recoil_player.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "augs/misc/randomization.h"
 #include "game/assets/recoil_player.h"
 

--- a/src/game/components/hand_fuse_component.h
+++ b/src/game/components/hand_fuse_component.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include "augs/graphics/rgba.h"
 #include "augs/misc/timing/stepped_timing.h"
 #include "game/detail/view_input/sound_effect_input.h"

--- a/src/game/components/movement_path_component.h
+++ b/src/game/components/movement_path_component.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include "augs/misc/enum/enum_array.h"
 #include "augs/misc/constant_size_vector.h"
 #include "augs/templates/maybe.h"

--- a/src/game/components/sentience_component.h
+++ b/src/game/components/sentience_component.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include <optional>
 
 #include "augs/graphics/rgba.h"

--- a/src/game/components/sorting_order_type.h
+++ b/src/game/components/sorting_order_type.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 
 using sorting_order_type = uint32_t;
 constexpr sorting_order_type max_sorting_layer_v = 64;

--- a/src/game/components/wandering_pixels_component.h
+++ b/src/game/components/wandering_pixels_component.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include "game/components/sprite_component.h"
 #include "augs/misc/constant_size_vector.h"
 #include "augs/pad_bytes.h"

--- a/src/game/cosmos/cosmic_entropy.cpp
+++ b/src/game/cosmos/cosmic_entropy.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "augs/templates/logically_empty.h"
 #include "augs/templates/container_templates.h"
 #include "cosmic_entropy.h"

--- a/src/game/cosmos/cosmic_entropy.h
+++ b/src/game/cosmos/cosmic_entropy.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <vector>
 #include <map>
 

--- a/src/game/cosmos/cosmic_functions.h
+++ b/src/game/cosmos/cosmic_functions.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "augs/templates/identity_templates.h"
 #include "game/cosmos/entity_flavour_id.h"
 #include "game/cosmos/entity_handle_declaration.h"

--- a/src/game/cosmos/cosmic_profiler.h
+++ b/src/game/cosmos/cosmic_profiler.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "augs/misc/profiler_mixin.h"
 
 struct cosmic_profiler : public augs::profiler_mixin<cosmic_profiler> {

--- a/src/game/cosmos/cosmos.cpp
+++ b/src/game/cosmos/cosmos.cpp
@@ -1,3 +1,4 @@
+#include <cstdint>
 #include "augs/ensure_rel.h"
 #include "3rdparty/crc32/crc32.h"
 

--- a/src/game/cosmos/cosmos.h
+++ b/src/game/cosmos/cosmos.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "augs/build_settings/compiler_defines.h"
 #include "augs/misc/randomization_declaration.h"
 

--- a/src/game/cosmos/cosmos_solvable.cpp
+++ b/src/game/cosmos/cosmos_solvable.cpp
@@ -1,3 +1,5 @@
+#include <cstddef>
+#include <cstdint>
 #include "game/cosmos/cosmos_solvable.h"
 
 #include "augs/templates/introspect.h"

--- a/src/game/cosmos/cosmos_solvable.h
+++ b/src/game/cosmos/cosmos_solvable.h
@@ -1,4 +1,6 @@
 #pragma once
+#include <cstddef>
+#include <cstdint>
 #include <map>
 #include "augs/templates/identity_templates.h"
 

--- a/src/game/cosmos/cosmos_solvable_inferred.h
+++ b/src/game/cosmos/cosmos_solvable_inferred.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #if PLATFORM_WINDOWS
 #pragma warning(disable : 4503)
 #endif

--- a/src/game/cosmos/entity_flavour_id.h
+++ b/src/game/cosmos/entity_flavour_id.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <string>
 #include "augs/templates/hash_templates.h"
 #include "augs/string/string_templates_declaration.h"

--- a/src/game/cosmos/entity_id.h
+++ b/src/game/cosmos/entity_id.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <type_traits>
 #include <compare>
 #include "augs/misc/pool/pooled_object_id.h"

--- a/src/game/cosmos/might_allocate_entities_having.hpp
+++ b/src/game/cosmos/might_allocate_entities_having.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "game/cosmos/cosmic_functions.h"
 #include "game/organization/for_each_entity_type.h"
 

--- a/src/game/cosmos/state_tests.cpp
+++ b/src/game/cosmos/state_tests.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #if !IS_PRODUCTION_BUILD
 #if BUILD_UNIT_TESTS
 #include "augs/log_direct.h"

--- a/src/game/debug_draw.cpp
+++ b/src/game/debug_draw.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "game/debug_draw.h"
 #include "3rdparty/Box2D/Collision/Shapes/b2PolygonShape.h"
 

--- a/src/game/debug_draw.h
+++ b/src/game/debug_draw.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <vector>
 #include "augs/math/declare_math.h"
 #include "augs/graphics/debug_line.h"

--- a/src/game/detail/ai/behaviours/immediate_evasion.cpp
+++ b/src/game/detail/ai/behaviours/immediate_evasion.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "game/detail/ai/behaviours.h"
 #include "game/cosmos/entity_id.h"
 

--- a/src/game/detail/describers.h
+++ b/src/game/detail/describers.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <string>
 #include <map>
 

--- a/src/game/detail/entity_handle_mixins/inventory_mixin.h
+++ b/src/game/detail/entity_handle_mixins/inventory_mixin.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <optional>
 
 #include "augs/templates/maybe_const.h"

--- a/src/game/detail/entity_handle_mixins/inventory_mixin.hpp
+++ b/src/game/detail/entity_handle_mixins/inventory_mixin.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "game/detail/entity_handle_mixins/inventory_mixin.h"
 #include "game/detail/entity_handle_mixins/get_owning_transfer_capability.hpp"
 #include "game/components/item_sync.h"

--- a/src/game/detail/explosive/detonate.cpp
+++ b/src/game/detail/explosive/detonate.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "game/components/explosive_component.h"
 #include "game/detail/explosive/detonate.h"
 #include "game/cosmos/logic_step.h"

--- a/src/game/detail/get_hovered_world_entity.h
+++ b/src/game/detail/get_hovered_world_entity.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "augs/templates/enum_introspect.h"
 #include "game/detail/visible_entities.hpp"
 

--- a/src/game/detail/hand_fuse_logic.h
+++ b/src/game/detail/hand_fuse_logic.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "game/cosmos/entity_handle.h"
 #include "game/cosmos/entity_id.h"
 #include "game/cosmos/step_declaration.h"

--- a/src/game/detail/inventory/generate_equipment.h
+++ b/src/game/detail/inventory/generate_equipment.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include "game/detail/inventory/requested_equipment.h"
 #include "game/enums/slot_function.h"
 #include "game/cosmos/just_create_entity.h"

--- a/src/game/detail/inventory/hand_count.h
+++ b/src/game/detail/inventory/hand_count.h
@@ -1,3 +1,4 @@
 #pragma once
+#include <cstddef>
 
 static constexpr std::size_t hand_count_v = 2;

--- a/src/game/detail/inventory/inventory_slot_handle.h
+++ b/src/game/detail/inventory/inventory_slot_handle.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <optional>
 #include "augs/templates/maybe_const.h"
 #include "augs/misc/enum/enum_boolset.h"

--- a/src/game/detail/inventory/inventory_slot_id.h
+++ b/src/game/detail/inventory/inventory_slot_id.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "game/enums/slot_function.h"
 #include "game/cosmos/entity_id.h"
 

--- a/src/game/detail/inventory/perform_wielding.hpp
+++ b/src/game/detail/inventory/perform_wielding.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "augs/templates/logically_empty.h"
 
 #define LOG_WIELDING 0

--- a/src/game/detail/inventory/requested_equipment.h
+++ b/src/game/detail/inventory/requested_equipment.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include "game/organization/special_flavour_id_types.h"
 #include "augs/misc/simple_pair.h"
 #include "game/cosmos/step_declaration.h"

--- a/src/game/detail/inventory/wielding_setup.h
+++ b/src/game/detail/inventory/wielding_setup.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <array>
 #include "game/cosmos/entity_id.h"
 

--- a/src/game/detail/inventory/wielding_setup.hpp
+++ b/src/game/detail/inventory/wielding_setup.hpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "game/detail/inventory/wielding_setup.h"
 #include "game/detail/weapon_like.h"
 #include "game/detail/gun/ammo_logic.h"

--- a/src/game/detail/physics/b2Fixture_index_in_component.h
+++ b/src/game/detail/physics/b2Fixture_index_in_component.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 
 struct b2Fixture_index_in_component {
 	std::size_t convex_shape_index = 0xdeadbeef;

--- a/src/game/detail/physics/physics_queries.h
+++ b/src/game/detail/physics/physics_queries.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <type_traits>
 
 #include <Box2D/Common/b2Math.h>

--- a/src/game/detail/sentience/sentience_getters.h
+++ b/src/game/detail/sentience/sentience_getters.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "game/components/sentience_component.h"
 #include "game/detail/sentience/tool_getters.h"
 

--- a/src/game/detail/transform_copying.h
+++ b/src/game/detail/transform_copying.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <variant>
 #include <optional>
 #include "game/cosmos/entity_id.h"

--- a/src/game/detail/view_input/sound_effect_input.cpp
+++ b/src/game/detail/view_input/sound_effect_input.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "game/detail/view_input/sound_effect_input.h"
 #include "game/cosmos/entity_handle.h"
 #include "game/cosmos/logic_step.h"

--- a/src/game/detail/view_input/sound_effect_input.h
+++ b/src/game/detail/view_input/sound_effect_input.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "augs/misc/constant_size_vector.h"
 #include "view/view_container_sizes.h"
 #include "augs/pad_bytes.h"

--- a/src/game/detail/visible_entities.cpp
+++ b/src/game/detail/visible_entities.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "augs/math/math.h"
 #include "augs/templates/algorithm_templates.h"
 #include "augs/templates/container_templates.h"

--- a/src/game/detail/visible_entities.h
+++ b/src/game/detail/visible_entities.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "augs/misc/enum/enum_array.h"
 
 #include "augs/templates/maybe.h"

--- a/src/game/inferred_caches/organism_cache.cpp
+++ b/src/game/inferred_caches/organism_cache.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "game/inferred_caches/organism_cache.h"
 #include "augs/templates/container_templates.h"
 #include "game/inferred_caches/organism_cache.hpp"

--- a/src/game/inferred_caches/organism_cache.h
+++ b/src/game/inferred_caches/organism_cache.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "game/inferred_caches/inferred_cache_common.h"
 #include "augs/math/rects.h"
 #include "augs/math/vec2.h"

--- a/src/game/inferred_caches/physics_world_cache.cpp
+++ b/src/game/inferred_caches/physics_world_cache.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #define DEBUG_PHYSICS_SYSTEM_COPY 0
 #include "3rdparty/Box2D/Box2D.h"
 

--- a/src/game/inferred_caches/physics_world_cache.h
+++ b/src/game/inferred_caches/physics_world_cache.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <memory>
 #include "3rdparty/Box2D/Dynamics/b2Filter.h"
 #include "augs/misc/constant_size_vector.h"

--- a/src/game/inferred_caches/processing_lists_cache.cpp
+++ b/src/game/inferred_caches/processing_lists_cache.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "augs/templates/container_templates.h"
 #include "augs/templates/enum_introspect.h"
 

--- a/src/game/inferred_caches/processing_lists_cache.h
+++ b/src/game/inferred_caches/processing_lists_cache.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <vector>
 
 #include "augs/misc/enum/enum_boolset.h"

--- a/src/game/inferred_caches/tree_of_npo_cache.cpp
+++ b/src/game/inferred_caches/tree_of_npo_cache.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "game/cosmos/logic_step.h"
 #include "game/cosmos/cosmos.h"
 #include "game/cosmos/entity_handle.h"

--- a/src/game/inferred_caches/tree_of_npo_cache.h
+++ b/src/game/inferred_caches/tree_of_npo_cache.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <vector>
 #include <optional>
 #include <Box2D/Collision/b2DynamicTree.h>

--- a/src/game/messages/visibility_information.h
+++ b/src/game/messages/visibility_information.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "message.h"
 #include <vector>
 #include "augs/graphics/rgba.h"

--- a/src/game/modes/arena_mode.cpp
+++ b/src/game/modes/arena_mode.cpp
@@ -1,3 +1,5 @@
+#include <cstddef>
+#include <cstdint>
 #include "augs/log.h"
 #include "augs/ensure_rel.h"
 #include "game/cosmos/solvers/standard_solver.h"

--- a/src/game/modes/arena_mode.h
+++ b/src/game/modes/arena_mode.h
@@ -1,4 +1,6 @@
 #pragma once
+#include <cstddef>
+#include <cstdint>
 #include <unordered_map>
 
 #include "augs/math/declare_math.h"

--- a/src/game/modes/arena_mode_structs.h
+++ b/src/game/modes/arena_mode_structs.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include "augs/misc/timing/stepped_timing.h"
 #include "game/assets/ids/asset_ids.h"
 #include "augs/misc/enum/enum_array.h"

--- a/src/game/modes/mode_helpers.h
+++ b/src/game/modes/mode_helpers.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "game/organization/all_entity_types.h"
 #include "game/components/attitude_component.h"
 #include "game/common_state/entity_flavours.h"

--- a/src/game/modes/mode_player_id.h
+++ b/src/game/modes/mode_player_id.h
@@ -1,4 +1,6 @@
 #pragma once
+#include <cstddef>
+#include <cstdint>
 #include "augs/network/network_types.h"
 #include "augs/templates/hash_templates.h"
 

--- a/src/game/modes/session_id.h
+++ b/src/game/modes/session_id.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 
 struct session_id_type {
 	using id_value_type = uint32_t;

--- a/src/game/modes/test_mode.cpp
+++ b/src/game/modes/test_mode.cpp
@@ -1,3 +1,5 @@
+#include <cstddef>
+#include <cstdint>
 #include "game/cosmos/solvers/standard_solver.h"
 #include "game/modes/test_mode.h"
 #include "game/modes/mode_entropy.h"

--- a/src/game/modes/test_mode.h
+++ b/src/game/modes/test_mode.h
@@ -1,4 +1,6 @@
 #pragma once
+#include <cstddef>
+#include <cstdint>
 #include "augs/math/declare_math.h"
 #include "game/detail/inventory/requested_equipment.h"
 #include "game/enums/faction_type.h"

--- a/src/game/organization/all_entity_types.h
+++ b/src/game/organization/all_entity_types.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "augs/templates/type_list.h"
 
 #include "game/organization/all_components_declaration.h"

--- a/src/game/organization/all_entity_types_declaration.h
+++ b/src/game/organization/all_entity_types_declaration.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "augs/templates/type_in_list_id.h"
 #include "augs/templates/folded_finders.h"
 

--- a/src/game/other_unit_tests.cpp
+++ b/src/game/other_unit_tests.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #if __FAST_MATH__
 #error "Don't do this"
 #endif

--- a/src/game/stateless_systems/gun_system.cpp
+++ b/src/game/stateless_systems/gun_system.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "augs/ensure_rel.h"
 #include "augs/misc/randomization.h"
 

--- a/src/game/stateless_systems/intent_contextualization_system.cpp
+++ b/src/game/stateless_systems/intent_contextualization_system.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "intent_contextualization_system.h"
 #include "game/messages/intent_message.h"
 #include "game/messages/motion_message.h"

--- a/src/game/stateless_systems/item_system.cpp
+++ b/src/game/stateless_systems/item_system.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "augs/templates/logically_empty.h"
 #include "augs/templates/container_templates.h"
 #include "game/stateless_systems/item_system.h"

--- a/src/game/stateless_systems/melee_system.cpp
+++ b/src/game/stateless_systems/melee_system.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "melee_system.h"
 #include "game/cosmos/cosmos.h"
 #include "game/cosmos/entity_id.h"

--- a/src/game/stateless_systems/missile_system.cpp
+++ b/src/game/stateless_systems/missile_system.cpp
@@ -1,3 +1,4 @@
+#include <cstdint>
 #include "missile_system.h"
 #include "augs/math/steering.h"
 #include "game/cosmos/cosmos.h"

--- a/src/game/stateless_systems/movement_path_system.cpp
+++ b/src/game/stateless_systems/movement_path_system.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "augs/misc/randomization.h"
 #include "augs/math/steering.h"
 #include "augs/math/make_rect_points.h"

--- a/src/game/stateless_systems/sentience_system.cpp
+++ b/src/game/stateless_systems/sentience_system.cpp
@@ -1,3 +1,4 @@
+#include <cstdint>
 #include "sentience_system.h"
 
 #include "augs/templates/get_by_dynamic_id.h"

--- a/src/game/stateless_systems/sound_existence_system.cpp
+++ b/src/game/stateless_systems/sound_existence_system.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "sound_existence_system.h"
 #include "game/cosmos/logic_step.h"
 #include "game/cosmos/cosmos.h"

--- a/src/game/stateless_systems/visibility_system.cpp
+++ b/src/game/stateless_systems/visibility_system.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "augs/math/repro_math.h"
 
 #include <limits>

--- a/src/introspector_generator_input.cfg.in
+++ b/src/introspector_generator_input.cfg.in
@@ -48,6 +48,8 @@ enum-arg-format:
 enum-to-args-body-format:
 generated-file-format:
 #pragma once
+#include <cstddef>
+#include <cstdint>
 #include <tuple>
 #include <string>
 

--- a/src/test_scenes/scenes/testbed.cpp
+++ b/src/test_scenes/scenes/testbed.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 /*
 	Disable float/int warnings, this is just a content script
 */

--- a/src/test_scenes/test_id_to_pool_id.h
+++ b/src/test_scenes/test_id_to_pool_id.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "game/assets/ids/asset_ids.h"
 
 template <class P, class T>

--- a/src/test_scenes/test_scene_animations.cpp
+++ b/src/test_scenes/test_scene_animations.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "augs/ensure_rel_util.h"
 #include "test_scenes/test_scenes_content.h"
 #include "test_scenes/test_scene_animations.h"

--- a/src/test_scenes/test_scene_particle_effects.cpp
+++ b/src/test_scenes/test_scene_particle_effects.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 /*
 	Disable float/int warnings, this is just a content script
 */

--- a/src/view/audiovisual_state/audiovisual_profiler.h
+++ b/src/view/audiovisual_state/audiovisual_profiler.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "augs/misc/profiler_mixin.h"
 
 struct audiovisual_profiler : public augs::profiler_mixin<audiovisual_profiler> {

--- a/src/view/audiovisual_state/audiovisual_state.cpp
+++ b/src/view/audiovisual_state/audiovisual_state.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "augs/string/string_templates.h"
 #include "augs/drawing/drawing_input_base.h"
 #include "augs/drawing/sprite.h"

--- a/src/view/audiovisual_state/audiovisual_state.h
+++ b/src/view/audiovisual_state/audiovisual_state.h
@@ -1,4 +1,6 @@
 #pragma once
+#include <cstddef>
+#include <cstdint>
 #include "augs/entity_system/storage_for_systems.h"
 #include "augs/math/camera_cone.h"
 

--- a/src/view/audiovisual_state/systems/damage_indication_system.h
+++ b/src/view/audiovisual_state/systems/damage_indication_system.h
@@ -1,4 +1,6 @@
 #pragma once
+#include <cstddef>
+#include <cstdint>
 #include <optional>
 #include <functional>
 

--- a/src/view/audiovisual_state/systems/exploding_ring_system.cpp
+++ b/src/view/audiovisual_state/systems/exploding_ring_system.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "augs/drawing/drawing.hpp"
 #include "augs/misc/randomization.h"
 #include "augs/templates/container_templates.h"

--- a/src/view/audiovisual_state/systems/exploding_ring_system.h
+++ b/src/view/audiovisual_state/systems/exploding_ring_system.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "augs/misc/bound.h"
 #include "augs/misc/timing/delta.h"
 #include "augs/misc/constant_size_vector.h"

--- a/src/view/audiovisual_state/systems/interpolation_system.cpp
+++ b/src/view/audiovisual_state/systems/interpolation_system.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "interpolation_system.h"
 #include "view/audiovisual_state/systems/interpolation_settings.h"
 #include "game/components/interpolation_component.h"

--- a/src/view/audiovisual_state/systems/interpolation_system.h
+++ b/src/view/audiovisual_state/systems/interpolation_system.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <vector>
 #include <optional>
 

--- a/src/view/audiovisual_state/systems/light_system.cpp
+++ b/src/view/audiovisual_state/systems/light_system.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "augs/graphics/vertex.h"
 #include "augs/graphics/renderer.h"
 #include "augs/graphics/shader.h"

--- a/src/view/audiovisual_state/systems/light_system.h
+++ b/src/view/audiovisual_state/systems/light_system.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <array>
 #include <functional>
 

--- a/src/view/audiovisual_state/systems/linear_cache_map.h
+++ b/src/view/audiovisual_state/systems/linear_cache_map.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "game/cosmos/per_entity_type.h"
 #include "augs/misc/constant_size_vector.h"
 

--- a/src/view/audiovisual_state/systems/particles_simulation_system.cpp
+++ b/src/view/audiovisual_state/systems/particles_simulation_system.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "augs/templates/container_templates.h"
 #include "game/detail/physics/physics_queries.h"
 

--- a/src/view/audiovisual_state/systems/particles_simulation_system.h
+++ b/src/view/audiovisual_state/systems/particles_simulation_system.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <unordered_map>
 #include "augs/misc/simple_pair.h"
 

--- a/src/view/audiovisual_state/systems/past_infection_system.h
+++ b/src/view/audiovisual_state/systems/past_infection_system.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <vector>
 #include "game/cosmos/entity_handle_declaration.h"
 #include "game/cosmos/entity_id.h"

--- a/src/view/audiovisual_state/systems/pure_color_highlight_system.h
+++ b/src/view/audiovisual_state/systems/pure_color_highlight_system.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "augs/misc/timing/delta.h"
 #include "augs/misc/bound.h"
 

--- a/src/view/audiovisual_state/systems/randomizing_system.cpp
+++ b/src/view/audiovisual_state/systems/randomizing_system.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "view/audiovisual_state/systems/randomizing_system.h"
 #include "augs/log.h"
 

--- a/src/view/audiovisual_state/systems/randomizing_system.h
+++ b/src/view/audiovisual_state/systems/randomizing_system.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "augs/misc/timing/delta.h"
 #include "augs/drawing/sprite.h"
 #include "augs/misc/randomization.h"

--- a/src/view/audiovisual_state/systems/sound_system.h
+++ b/src/view/audiovisual_state/systems/sound_system.h
@@ -1,4 +1,6 @@
 #pragma once
+#include <cstddef>
+#include <cstdint>
 #include <unordered_map>
 
 #include "augs/misc/timing/delta.h"

--- a/src/view/audiovisual_state/systems/thunder_system.cpp
+++ b/src/view/audiovisual_state/systems/thunder_system.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "augs/misc/randomization.h"
 #include "augs/templates/container_templates.h"
 #include "augs/drawing/drawing.hpp"

--- a/src/view/audiovisual_state/systems/thunder_system.h
+++ b/src/view/audiovisual_state/systems/thunder_system.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "augs/misc/bound.h"
 #include "augs/misc/timing/delta.h"
 #include "augs/graphics/rgba.h"

--- a/src/view/audiovisual_state/systems/wandering_pixels_system.h
+++ b/src/view/audiovisual_state/systems/wandering_pixels_system.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "augs/misc/timing/delta.h"
 #include "augs/misc/randomization.h"
 

--- a/src/view/frame_profiler.h
+++ b/src/view/frame_profiler.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "augs/misc/profiler_mixin.h"
 
 struct frame_profiler : public augs::profiler_mixin<frame_profiler> {

--- a/src/view/game_gui/elements/character_gui.cpp
+++ b/src/view/game_gui/elements/character_gui.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "augs/ensure.h"
 #include "augs/log.h"
 #include "view/game_gui/game_gui_element_location.h"

--- a/src/view/game_gui/elements/character_gui.h
+++ b/src/view/game_gui/elements/character_gui.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <unordered_map>
 #include <array>
 

--- a/src/view/game_gui/elements/game_gui_root.h
+++ b/src/view/game_gui/elements/game_gui_root.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "view/game_gui/game_gui_element_location.h"
 #include "view/game_gui/elements/item_button.h"
 

--- a/src/view/game_gui/elements/hotbar_button.cpp
+++ b/src/view/game_gui/elements/hotbar_button.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "augs/drawing/drawing.hpp"
 #include "augs/templates/container_templates.h"
 #include "hotbar_button.h"

--- a/src/view/game_gui/elements/item_button.h
+++ b/src/view/game_gui/elements/item_button.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "augs/pad_bytes.h"
 
 #include "augs/gui/rect.h"

--- a/src/view/game_gui/elements/locations/action_button_in_character_gui.h
+++ b/src/view/game_gui/elements/locations/action_button_in_character_gui.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 
 class action_button;
 

--- a/src/view/game_gui/elements/locations/drag_and_drop_target_drop_item_in_character_gui.h
+++ b/src/view/game_gui/elements/locations/drag_and_drop_target_drop_item_in_character_gui.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 
 struct drag_and_drop_target_drop_item;
 

--- a/src/view/game_gui/elements/locations/game_gui_root_in_context.h
+++ b/src/view/game_gui/elements/locations/game_gui_root_in_context.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 
 class game_gui_root;
 

--- a/src/view/game_gui/elements/locations/hotbar_button_in_character_gui.h
+++ b/src/view/game_gui/elements/locations/hotbar_button_in_character_gui.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "augs/templates/hash_fwd.h"
 
 class hotbar_button;

--- a/src/view/game_gui/elements/locations/item_button_in_item.h
+++ b/src/view/game_gui/elements/locations/item_button_in_item.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "game/cosmos/entity_id.h"
 #include "game/detail/entity_handle_mixins/get_owning_transfer_capability.hpp"
 #include "augs/templates/hash_fwd.h"

--- a/src/view/game_gui/elements/locations/root_of_inventory_gui_in_context.h
+++ b/src/view/game_gui/elements/locations/root_of_inventory_gui_in_context.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 
 class game_gui_root;
 

--- a/src/view/game_gui/elements/locations/slot_button_in_container.h
+++ b/src/view/game_gui/elements/locations/slot_button_in_container.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "game/detail/inventory/inventory_slot_id.h"
 #include "game/detail/entity_handle_mixins/get_owning_transfer_capability.hpp"
 #include "augs/templates/hash_fwd.h"

--- a/src/view/game_gui/elements/locations/value_bar_in_character_gui.h
+++ b/src/view/game_gui/elements/locations/value_bar_in_character_gui.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "augs/templates/type_list.h"
 
 #include "game/detail/all_sentience_meters.h"

--- a/src/view/game_gui/elements/value_bar.cpp
+++ b/src/view/game_gui/elements/value_bar.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "augs/misc/randomization.h"
 #include "augs/templates/get_by_dynamic_id.h"
 #include "augs/gui/text/printer.h"

--- a/src/view/game_gui/game_gui_system.cpp
+++ b/src/view/game_gui/game_gui_system.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "augs/templates/container_templates.h"
 #include "augs/gui/button_corners.h"
 

--- a/src/view/game_gui/game_gui_system.h
+++ b/src/view/game_gui/game_gui_system.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <unordered_map>
 
 #include "augs/misc/timing/delta.h"

--- a/src/view/mode_gui/arena/arena_choose_team_gui.h
+++ b/src/view/mode_gui/arena/arena_choose_team_gui.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <vector>
 #include <optional>
 #include "game/enums/faction_type.h"

--- a/src/view/mode_gui/arena/arena_context_tip.h
+++ b/src/view/mode_gui/arena/arena_context_tip.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "game/detail/buy_area_in_range.h"
 #include "game/detail/bombsite_in_range.h"
 #include "game/detail/entity_handle_mixins/for_each_slot_and_item.hpp"

--- a/src/view/mode_gui/arena/arena_mode_gui.cpp
+++ b/src/view/mode_gui/arena/arena_mode_gui.cpp
@@ -1,3 +1,5 @@
+#include <cstddef>
+#include <cstdint>
 #include "augs/drawing/drawing.hpp"
 #include "augs/templates/logically_empty.h"
 #include "view/mode_gui/arena/arena_mode_gui.h"

--- a/src/view/mode_gui/arena/arena_player_meta.h
+++ b/src/view/mode_gui/arena/arena_player_meta.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include <array>
 #include "augs/network/network_types.h"
 #include "application/network/requested_client_settings.h"

--- a/src/view/mode_gui/arena/arena_scoreboard_gui.cpp
+++ b/src/view/mode_gui/arena/arena_scoreboard_gui.cpp
@@ -1,3 +1,4 @@
+#include <cstdint>
 #include "augs/log.h"
 #include "augs/drawing/drawing.hpp"
 #include "augs/gui/text/printer.h"

--- a/src/view/ranks_info.h
+++ b/src/view/ranks_info.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "view/necessary_image_id.h"
 
 struct rank_info {

--- a/src/view/rendering_scripts/draw_offscreen_indicator.h
+++ b/src/view/rendering_scripts/draw_offscreen_indicator.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "augs/math/math.h"
 #include "augs/drawing/drawing.hpp"
 

--- a/src/view/rendering_scripts/draw_sentiences_hud.cpp
+++ b/src/view/rendering_scripts/draw_sentiences_hud.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "rendering_scripts.h"
 #include "game/cosmos/cosmos.h"
 #include "game/detail/entity_handle_mixins/inventory_mixin.hpp"

--- a/src/view/rendering_scripts/draw_wandering_pixels_as_sprites.h
+++ b/src/view/rendering_scripts/draw_wandering_pixels_as_sprites.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "view/audiovisual_state/systems/wandering_pixels_system.h"
 #include "game/components/sprite_component.h"
 #include "game/enums/render_layer.h"

--- a/src/view/rendering_scripts/launch_visibility_jobs.h
+++ b/src/view/rendering_scripts/launch_visibility_jobs.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "view/rendering_scripts/vis_response_to_triangles.h"
 #include "game/enums/filters.h"
 

--- a/src/view/rendering_scripts/vis_response_to_triangles.h
+++ b/src/view/rendering_scripts/vis_response_to_triangles.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 
 inline void vis_response_to_triangles(
 	const visibility_response& response, 

--- a/src/view/view_container_sizes.h
+++ b/src/view/view_container_sizes.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 
 constexpr std::size_t MAX_EXPLODING_RINGS = 300;
 

--- a/src/view/viewables/ad_hoc_in_atlas_map.h
+++ b/src/view/viewables/ad_hoc_in_atlas_map.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include <unordered_map>
 #include "view/viewables/image_in_atlas.h"
 #include "game/assets/animation_math.h"

--- a/src/view/viewables/images_in_atlas_map.h
+++ b/src/view/viewables/images_in_atlas_map.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "augs/templates/container_templates.h"
 #include "game/container_sizes.h"
 #include "game/assets/ids/asset_ids.h"

--- a/src/view/viewables/particle_types.h
+++ b/src/view/viewables/particle_types.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "augs/drawing/drawing.h"
 #include "augs/math/vec2.h"
 #include "view/viewables/particle_types_declaration.h"

--- a/src/view/viewables/regeneration/buttons_with_corners.cpp
+++ b/src/view/viewables/regeneration/buttons_with_corners.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "augs/log.h"
 #include "augs/gui/button_corners.h"
 

--- a/src/view/viewables/regeneration/neon_maps.cpp
+++ b/src/view/viewables/regeneration/neon_maps.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include <sstream>
 
 #include "augs/filesystem/file.h"

--- a/src/view/viewables/standard_atlas_distribution.cpp
+++ b/src/view/viewables/standard_atlas_distribution.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include <unordered_set>
 
 #include "view/viewables/atlas_distributions.h"

--- a/src/view/viewables/streaming/viewables_streaming_profiler.h
+++ b/src/view/viewables/streaming/viewables_streaming_profiler.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include "augs/misc/measurements.h"
 #include "augs/misc/profiler_mixin.h"
 

--- a/src/work.cpp
+++ b/src/work.cpp
@@ -1,3 +1,4 @@
+#include <cstdint>
 /*
 	BEFORE YOU CONTINUE:
 


### PR DESCRIPTION
Add some missing includes for common symbols that were assumed to be pulled through other includes. This is not comprehensive (I didn't get [IWYU](https://github.com/include-what-you-use/include-what-you-use) to work _yet_), but it's enough to make GCC stop complaining. See https://github.com/TeamHypersomnia/Hypersomnia/commit/ed08a6de62e893ecd3cc53871edd836616e8f19f for the bash script I used to add all of those.

Also, invert the preprocessor condition that guards the use of some Windows APIs, so that Linux+non-Clang doesn't attempt to use it.

Tested on Fedora 42 with:
```
# I have to ask the compiler to not shit itself or linking fails, some GCC weirdness I guess
cmake -DARCHITECTURE=native -DCMAKE_CXX_FLAGS='-w -fno-ipa-sra' -Bbuild -S.
cmake --build build -j16
```

@suve it's a bit more than what we got to work originally, but `fedpkg --release f43 mockbuild` worked for me on this too.