### PR TITLE
streflop: only use x87 FPU assembly and SSE flags on x86/x86_64

### DIFF
--- a/src/3rdparty/streflop/CMakeLists.txt
+++ b/src/3rdparty/streflop/CMakeLists.txt
@@ -1,4 +1,7 @@
 # Spring supplied CMake build file
+# Patched to avoid using SSE compiler flags on platforms that don't support SSE.
+
+include(CheckCXXCompilerFlag)
 
 add_definitions(-DSTREFLOP_SSE)
 
@@ -75,7 +78,12 @@ SET(libm_flt32_source
 SET(cxxflags "-DLIBM_COMPILING_FLT32 -Wno-unused-parameter -I\"${CMAKE_CURRENT_SOURCE_DIR}/libm/headers\"")
 
 if (CLANG OR GCC)
-	SET(cxxflags "${cxxflags} -fno-strict-aliasing -msse -msse2")
+	SET(cxxflags "${cxxflags} -fno-strict-aliasing")
+
+	check_cxx_compiler_flag("-msse;-msse2" SSE2_SUPPORTED)
+	if (SSE2_SUPPORTED)
+		SET(cxxflags "${cxxflags} -msse -msse2")
+	endif()
 
 	if (BUILD_FOR_WEB)
 		SET(cxxflags "${cxxflags} -msimd128")

--- a/src/3rdparty/streflop/FPUSettings.h
+++ b/src/3rdparty/streflop/FPUSettings.h
@@ -131,22 +131,22 @@ enum FPU_RoundMode {
 */
 
 // plan for portability
-#if defined(_MSC_VER)
-#define STREFLOP_FSTCW(cw) do { short tmp; __asm { fstcw tmp }; (cw) = tmp; } while (0)
-#define STREFLOP_FLDCW(cw) do { short tmp = (cw); __asm { fclex }; __asm { fldcw tmp }; } while (0)
-#define STREFLOP_STMXCSR(cw) do { int tmp; __asm { stmxcsr tmp }; (cw) = tmp; } while (0)
-#define STREFLOP_LDMXCSR(cw) do { int tmp = (cw); __asm { ldmxcsr tmp }; } while (0)
-#elif PLATFORM_WEB || PLATFORM_ARM64
-#define STREFLOP_FSTCW(cw) (cw=0);
-#define STREFLOP_FLDCW(cw) ((void)cw);
-#define STREFLOP_STMXCSR(cw) (cw=0);
-#define STREFLOP_LDMXCSR(cw) ((void)cw);
-#else
+#if defined(__i386__) || defined(__x86_64__)
 #define STREFLOP_FSTCW(cw) do { asm volatile ("fstcw %0" : "=m" (cw) : ); } while (0)
 #define STREFLOP_FLDCW(cw) do { asm volatile ("fclex \n fldcw %0" : : "m" (cw)); } while (0)
 #define STREFLOP_STMXCSR(cw) do { asm volatile ("stmxcsr %0" : "=m" (cw) : ); } while (0)
 #define STREFLOP_LDMXCSR(cw) do { asm volatile ("ldmxcsr %0" : : "m" (cw) ); } while (0)
-#endif // defined(_MSC_VER)
+#elif defined(_M_IX86) || defined(_M_AMD64)
+#define STREFLOP_FSTCW(cw) do { short tmp; __asm { fstcw tmp }; (cw) = tmp; } while (0)
+#define STREFLOP_FLDCW(cw) do { short tmp = (cw); __asm { fclex }; __asm { fldcw tmp }; } while (0)
+#define STREFLOP_STMXCSR(cw) do { int tmp; __asm { stmxcsr tmp }; (cw) = tmp; } while (0)
+#define STREFLOP_LDMXCSR(cw) do { int tmp = (cw); __asm { ldmxcsr tmp }; } while (0)
+#else
+#define STREFLOP_FSTCW(cw) (cw=0);
+#define STREFLOP_FLDCW(cw) ((void)cw);
+#define STREFLOP_STMXCSR(cw) (cw=0);
+#define STREFLOP_LDMXCSR(cw) ((void)cw);
+#endif
 
 // Subset of all C99 functions
 


### PR DESCRIPTION
This fixes builds some non-x86 builds on Fedora packaging infra.

- At configure time check if the compiler supports `-msse -msse2` flags. Only use them when they are supported.
- Reorganize platform check macros in `FPUSettings.h`:

  - Make the default case *not* use x87 FPU assembly. Enable it only when building for x86{,_64}.
  - Use MSVC-specific architecture identification macros to pick MSVC flavor of inline assembly. 

 Tested with:
- A local build on x86_64 Fedora 42.
- A fedora COPR build for all fedora-43* builds + `-DADD_MCMODEL_LARGE_FLAG=OFF` (the default caused more errors)

cc @suve